### PR TITLE
Scales size to viewport height

### DIFF
--- a/src/rard/templates/base.html
+++ b/src/rard/templates/base.html
@@ -126,11 +126,6 @@
           height: 30px;
           margin: 5px 5px 5px 5px;
       }
-      .symbol-palette {
-        display:none;
-        height:400px;
-        overflow-y: auto;
-      }
     </style>
 
     {% endblock %}

--- a/src/rard/templates/research/base.html
+++ b/src/rard/templates/research/base.html
@@ -40,10 +40,16 @@
 }
 
 /* Add styles to the form container */
-.form-container {
+.symbol-popup .form-container {
   max-width: 300px;
   padding: 10px;
   background-color: white;
+}
+
+.symbol-palette {
+  display:none;
+  max-height: 33vh;
+  overflow-y: auto;
 }
 
 /* .ordered-list-item:first-of-type .form-group [name*='up']  {
@@ -58,7 +64,7 @@
 
 
 /* Full-width textarea */
-.form-container textarea {
+.symbol-popup .form-container textarea {
   width: 100%;
   padding: 15px;
   margin: 5px 0 22px 0;
@@ -69,13 +75,13 @@
 }
 
 /* When the textarea gets focus, do something */
-.form-container textarea:focus {
+.symbol-popup .form-container textarea:focus {
   background-color: #ddd;
   outline: none;
 }
 
 /* Add some hover effects to buttons */
-.form-container .btn:hover, .open-button:hover {
+.symbol-popup .form-container .btn:hover, .open-button:hover {
   opacity: 1;
 }
 


### PR DESCRIPTION
Easy fix to scale the height of the symbol picker according to the viewport height.

Tested on screen sizes right down to VGA (640x480). If anyone using a screen smaller than this then I suggest they should be included in the historical research as an item of interest.

Fix #81 