### PR TITLE
Copied restart and healthcheck to production

### DIFF
--- a/src/production.yml
+++ b/src/production.yml
@@ -32,6 +32,16 @@ services:
       - ./.envs/.production/.django
       - ./.envs/.production/.postgres
     command: /start
+    restart: always
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - "-c"
+        - "import requests;exit(399<requests.get('http://localhost:5000',allow_redirects=False).status_code)"
+      timeout: 10s
+      interval: 1m
+      retries: 3
 
   postgres:
     build:
@@ -48,6 +58,12 @@ services:
         target: /backups
     env_file:
       - ./.envs/.production/.postgres
+    restart: always
+    healthcheck:
+      test: "pg_isready -q -U $$POSTGRES_USER -d $$POSTGRES_DB"
+      timeout: 45s
+      interval: 10s
+      retries: 10
 
   elasticsearch:
     container_name: elasticsearch
@@ -69,6 +85,7 @@ services:
       - ./.envs/.production/.pgadmin
     depends_on:
       - postgres
+    restart: always
 
   nginx:
     build:
@@ -91,3 +108,4 @@ services:
       - django
       - pgadmin
       - elasticsearch
+    restart: always


### PR DESCRIPTION
I can't check this directly, but the changes are (mostly) copied from development.yml
#241 Docker healthcheck on containers (and restart policy)