### PR TITLE
Add python explicitly in exec command

### DIFF
--- a/src/loaddata.sh
+++ b/src/loaddata.sh
@@ -12,7 +12,7 @@ if [ -n "${container}" ]
 then
 echo ${environment} environment
 docker cp $1 ${container}:/app/dump.json
-docker exec -it ${container} /bin/bash -c ". /entrypoint && LOADING=true ./manage.py loaddata /app/dump.json"
+docker exec -it ${container} /bin/bash -c ". /entrypoint && LOADING=true python ./manage.py loaddata /app/dump.json"
 exit 0
 fi
 done


### PR DESCRIPTION
I got an error `/usr/bin/env: ‘python\r’: No such file or directory` when trying this first time around. Adding `python` fixed it for me.