### PR TITLE
Fix/prepare for django 3.2

### DIFF
--- a/src/config/settings/base.py
+++ b/src/config/settings/base.py
@@ -36,6 +36,7 @@ USE_L10N = True
 USE_TZ = True
 # https://docs.djangoproject.com/en/dev/ref/settings/#locale-paths
 LOCALE_PATHS = [str(ROOT_DIR / "locale")]
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
 # DATABASES
 # ------------------------------------------------------------------------------

--- a/src/rard/research/apps.py
+++ b/src/rard/research/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class ResearchConfig(AppConfig):
-    name = 'research'
+    name = 'rard.research'


### PR DESCRIPTION
ResearchConfig's name attribute is incorrect (compare with UserConfig), so this is corrected. This becomes a problem if we ever move to Django 3.2
We would also need this DEFAULT_AUTO_FIELD if we ever move to Django 3.2, it's harmless if we don't.
So, we can add this now while we know what it is, or leave it until or unless we need to move to 3.2
I wanted to move to 3.2 so we get Collate() for adding collation to database queries, but this all didn't work.
So this is the "useful" output (plus the fact that we can't use collation for the Latin folding work) from my investigation.