### PR TITLE
Fix/development server config

### DIFF
--- a/src/compose/development/nginx/certs/rardselfsigned.cnf
+++ b/src/compose/development/nginx/certs/rardselfsigned.cnf
@@ -4,9 +4,15 @@ prompt = no
 encrypt_key = no
 default_md = sha256
 distinguished_name = dn
+x509_extensions = v3_req
 
 [ dn ]
 C = GB
 L = London
 O = University College London
 CN = frra-app01p.ad.ucl.ac.uk
+
+[ v3_req ]
+subjectAltName = @alt_names
+[ alt_names ]
+DNS.1 = frra-pp-10-00_524.gtm.ucl.ac.uk

--- a/src/compose/development/nginx/conf.d/rard.conf
+++ b/src/compose/development/nginx/conf.d/rard.conf
@@ -16,7 +16,7 @@ server {
         root /;
     }
 
-    location /frrant {
+    location /history/frrant {
         resolver 127.0.0.11;
         proxy_pass http://django;
         proxy_set_header Host $http_host;
@@ -49,7 +49,7 @@ server {
     }
 
     # Django for everything else
-    location /frrant/ {
+    location /history/frrant/ {
         resolver 127.0.0.11;
         proxy_pass http://django;
         proxy_set_header Host $http_host;

--- a/src/compose/development/nginx/conf.d/rard.conf
+++ b/src/compose/development/nginx/conf.d/rard.conf
@@ -6,7 +6,7 @@ upstream django {
 server {
     listen 80;
 
-    server_name frra-app01p.ad.ucl.ac.uk;
+    server_name frra-app01p.ad.ucl.ac.uk frra-pp-10-00_524.gtm.ucl.ac.uk;
 
     # Permanent HTTPS redirect
     #return 302 https://$server_name$request_uri;
@@ -41,7 +41,7 @@ server {
     include /etc/nginx/snippets/certificates.conf;
     include /etc/nginx/snippets/ssl-params.conf;
 
-    server_name frra-app01p.ad.ucl.ac.uk;
+    server_name frra-app01p.ad.ucl.ac.uk frra-pp-10-00_524.gtm.ucl.ac.uk;
 
     location = /favicon.ico { access_log off; log_not_found off; }
     location /static/ {

--- a/src/compose/development/nginx/conf.d/rard.conf
+++ b/src/compose/development/nginx/conf.d/rard.conf
@@ -12,15 +12,15 @@ server {
     #return 302 https://$server_name$request_uri;
     #return 302 https://$http_host$request_uri;
 
-    location /static/ {
+    location /history/frrant-preprod/static/ {
         root /;
     }
 
-    location /history/frrant {
+    location /history/frrant-preprod {
         resolver 127.0.0.11;
         proxy_pass http://django;
         proxy_set_header Host $http_host;
-        proxy_set_header SCRIPT_NAME /frrant;
+        proxy_set_header SCRIPT_NAME /frrant-preprod;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
@@ -44,16 +44,16 @@ server {
     server_name frra-app01p.ad.ucl.ac.uk frra-pp-10-00_524.gtm.ucl.ac.uk;
 
     location = /favicon.ico { access_log off; log_not_found off; }
-    location /static/ {
+    location /history/frrant-preprod/static/ {
         root /;
     }
 
     # Django for everything else
-    location /history/frrant/ {
+    location /history/frrant-preprod {
         resolver 127.0.0.11;
         proxy_pass http://django;
         proxy_set_header Host $http_host;
-        proxy_set_header SCRIPT_NAME /frrant;
+        proxy_set_header SCRIPT_NAME /frrant-preprod;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;

--- a/src/compose/development/nginx/conf.d/rard.conf
+++ b/src/compose/development/nginx/conf.d/rard.conf
@@ -6,7 +6,7 @@ upstream django {
 server {
     listen 80;
 
-    server_name frra-app01p.ad.ucl.ac.uk frra-pp-10-00_524.gtm.ucl.ac.uk;
+    server_name www.ucl.ac.uk frra-app01p.ad.ucl.ac.uk frra-pp-10-00_524.gtm.ucl.ac.uk;
 
     # Permanent HTTPS redirect
     #return 302 https://$server_name$request_uri;
@@ -16,11 +16,10 @@ server {
         alias /static/;
     }
 
-    location /history/frrant-preprod {
+    location / {
         resolver 127.0.0.11;
         proxy_pass http://django;
         proxy_set_header Host $http_host;
-        proxy_set_header SCRIPT_NAME /history/frrant-preprod;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;

--- a/src/compose/development/nginx/conf.d/rard.conf
+++ b/src/compose/development/nginx/conf.d/rard.conf
@@ -13,14 +13,14 @@ server {
     #return 302 https://$http_host$request_uri;
 
     location /history/frrant-preprod/static/ {
-        root /;
+        alias /static/;
     }
 
     location /history/frrant-preprod {
         resolver 127.0.0.11;
         proxy_pass http://django;
         proxy_set_header Host $http_host;
-        proxy_set_header SCRIPT_NAME /frrant-preprod;
+        proxy_set_header SCRIPT_NAME /history/frrant-preprod;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
@@ -45,17 +45,24 @@ server {
 
     location = /favicon.ico { access_log off; log_not_found off; }
     location /history/frrant-preprod/static/ {
-        root /;
+        # Serve /history/frrant-preprod/static/PATH from directory /static/PATH
+        alias /static/;
     }
 
     # Django for everything else
     location /history/frrant-preprod {
+        # Use docker DNS to resolve //django correctly
         resolver 127.0.0.11;
+        # Proxy /history/frrant-preprod/PATH to http://django/PATH
         proxy_pass http://django;
+        # Tell Django what the original request was for
         proxy_set_header Host $http_host;
-        proxy_set_header SCRIPT_NAME /frrant-preprod;
+        # Tell Django which bit of the path is the prefix
+        proxy_set_header SCRIPT_NAME /history/frrant-preprod;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        # Tell Django that this was originally a secure request so
+        # that it does not try to redirect infinitely
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 }

--- a/src/compose/development/nginx/conf.d/rard.conf
+++ b/src/compose/development/nginx/conf.d/rard.conf
@@ -56,7 +56,6 @@ server {
         proxy_pass http://django;
         # Tell Django what the original request was for
         proxy_set_header Host $http_host;
-        # Tell Django which bit of the path is the prefix
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         # Tell Django that this was originally a secure request so

--- a/src/compose/development/nginx/conf.d/rard.conf
+++ b/src/compose/development/nginx/conf.d/rard.conf
@@ -52,7 +52,6 @@ server {
     location / {
         # Use docker DNS to resolve //django correctly
         resolver 127.0.0.11;
-        # Proxy /history/frrant-preprod/PATH to http://django/PATH
         proxy_pass http://django;
         # Tell Django what the original request was for
         proxy_set_header Host $http_host;

--- a/src/compose/development/nginx/conf.d/rard.conf
+++ b/src/compose/development/nginx/conf.d/rard.conf
@@ -41,7 +41,7 @@ server {
     include /etc/nginx/snippets/certificates.conf;
     include /etc/nginx/snippets/ssl-params.conf;
 
-    server_name frra-app01p.ad.ucl.ac.uk frra-pp-10-00_524.gtm.ucl.ac.uk;
+    server_name www.ucl.ac.uk frra-app01p.ad.ucl.ac.uk frra-pp-10-00_524.gtm.ucl.ac.uk;
 
     location = /favicon.ico { access_log off; log_not_found off; }
     location /history/frrant-preprod/static/ {
@@ -50,7 +50,7 @@ server {
     }
 
     # Django for everything else
-    location /history/frrant-preprod {
+    location / {
         # Use docker DNS to resolve //django correctly
         resolver 127.0.0.11;
         # Proxy /history/frrant-preprod/PATH to http://django/PATH
@@ -58,7 +58,6 @@ server {
         # Tell Django what the original request was for
         proxy_set_header Host $http_host;
         # Tell Django which bit of the path is the prefix
-        proxy_set_header SCRIPT_NAME /history/frrant-preprod;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         # Tell Django that this was originally a secure request so

--- a/src/config/settings/base.py
+++ b/src/config/settings/base.py
@@ -134,12 +134,18 @@ MIDDLEWARE = [
     "simple_history.middleware.HistoryRequestMiddleware",
 ]
 
+# PREFIX
+# in the form folder/path/etc/ with trailing slash
+# e.g. 'history/frrant/'
+# ------------------------------------------------------------------------------
+URL_PREFIX = env("URL_PREFIX", default="")
+
 # STATIC
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#static-root
 STATIC_ROOT = str(ROOT_DIR / "staticfiles")
 # https://docs.djangoproject.com/en/dev/ref/settings/#static-url
-STATIC_URL = "static/"
+STATIC_URL = "/{}static/".format(URL_PREFIX)
 
 # https://docs.djangoproject.com/en/dev/ref/contrib/staticfiles/#std:setting-STATICFILES_DIRS
 STATICFILES_DIRS = [str(APPS_DIR / "static")]

--- a/src/config/settings/base.py
+++ b/src/config/settings/base.py
@@ -134,18 +134,12 @@ MIDDLEWARE = [
     "simple_history.middleware.HistoryRequestMiddleware",
 ]
 
-# PREFIX
-# in the form folder/path/etc/ with trailing slash
-# e.g. 'history/frrant/'
-# ------------------------------------------------------------------------------
-URL_PREFIX = env("URL_PREFIX", default="")
-
 # STATIC
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#static-root
 STATIC_ROOT = str(ROOT_DIR / "staticfiles")
 # https://docs.djangoproject.com/en/dev/ref/settings/#static-url
-STATIC_URL = "/{}static/".format(URL_PREFIX)
+STATIC_URL = "static/"
 
 # https://docs.djangoproject.com/en/dev/ref/contrib/staticfiles/#std:setting-STATICFILES_DIRS
 STATICFILES_DIRS = [str(APPS_DIR / "static")]

--- a/src/config/settings/base.py
+++ b/src/config/settings/base.py
@@ -232,9 +232,8 @@ EMAIL_TIMEOUT = 5
 ADMIN_URL = "admin/"
 # https://docs.djangoproject.com/en/dev/ref/settings/#admins
 ADMINS = [
-    ("""UCL""", "j.p.cooper@ucl.ac.uk"),
     ("""UCL""", "r.alegre@ucl.ac.uk"),
-    ("""UCL""", "a.georgoulas@ucl.ac.uk"),
+    ("Tom Couch", "t.couch@ucl.ac.uk"),
 ]
 
 # https://docs.djangoproject.com/en/dev/ref/settings/#managers

--- a/src/config/settings/development.py
+++ b/src/config/settings/development.py
@@ -23,9 +23,8 @@ SECRET_KEY = env("DJANGO_SECRET_KEY")
 # https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts
 ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS", default=["frra-app01p.ad.ucl.ac.uk"])
 ADMINS = [
-    ("""UCL""", "p.bispham@ucl.ac.uk"),
     ("""UCL""", "r.alegre@ucl.ac.uk"),
-    ("""UCL""", "a.georgoulas@ucl.ac.uk"),
+    ("Tom Couch", "t.couch@ucl.ac.uk"),
 ]
 
 

--- a/src/config/settings/development.py
+++ b/src/config/settings/development.py
@@ -1,6 +1,21 @@
 from .base import *  # noqa
 from .base import env
 
+
+def monkey_patch():
+    """
+    Django doesn't allow underscores in hostnames. This should overwrite that.
+    """
+    import django.http.request
+    from django.utils.regex_helper import _lazy_re_compile
+
+    django.http.request.host_validation_re = _lazy_re_compile(
+        r"^([a-z0-9._-]+|\[[a-f0-9]*:[a-f0-9\.:]+\])(:\d+)?$"
+    )
+
+
+monkey_patch()
+
 # GENERAL
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#secret-key

--- a/src/config/settings/development.py
+++ b/src/config/settings/development.py
@@ -53,6 +53,9 @@ SECURE_SSL_REDIRECT = env.bool("DJANGO_SECURE_SSL_REDIRECT", default=True)
 SESSION_COOKIE_SECURE = True
 # https://docs.djangoproject.com/en/dev/ref/settings/#csrf-cookie-secure
 CSRF_COOKIE_SECURE = True
+
+CSRF_TRUSTED_ORIGINS = ["www.ucl.ac.uk"]
+
 # https://docs.djangoproject.com/en/dev/topics/security/#ssl-https
 # https://docs.djangoproject.com/en/dev/ref/settings/#secure-hsts-seconds
 # TODO: set this to 60 seconds first and then to 518400 once you prove the former works

--- a/src/config/settings/production.py
+++ b/src/config/settings/production.py
@@ -8,9 +8,8 @@ SECRET_KEY = env("DJANGO_SECRET_KEY")
 # https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts
 ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS", default=["frra-app01.ad.ucl.ac.uk"])
 ADMINS = [
-    ("""UCL""", "p.bispham@ucl.ac.uk"),
     ("""UCL""", "r.alegre@ucl.ac.uk"),
-    ("""UCL""", "a.georgoulas@ucl.ac.uk"),
+    ("Tom Couch", "t.couch@ucl.ac.uk"),
 ]
 
 # DATABASES

--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -54,7 +54,7 @@ if settings.DEBUG:
             path("__debug__/", include(debug_toolbar.urls))
         ] + base_urlpatterns
 
-prefix = getattr(settings, "URL_PREFIX", None)
+prefix = getattr(settings, "URL_PREFIX", "")
 
 
 urlpatterns = [path("{}".format(prefix), include((base_urlpatterns)))]

--- a/src/requirements/base.txt
+++ b/src/requirements/base.txt
@@ -8,7 +8,7 @@ hiredis==1.1.0  # https://github.com/redis/hiredis-py
 
 # Django
 # ------------------------------------------------------------------------------
-django==3.1  # https://www.djangoproject.com/
+django==3.2  # https://www.djangoproject.com/
 django-environ==0.4.5  # https://github.com/joke2k/django-environ
 django-model-utils==4.0.0  # https://github.com/jazzband/django-model-utils
 django-redis==4.12.1  # https://github.com/jazzband/django-redis


### PR DESCRIPTION
We have a new hostname for the pre-prod server (frra-pp-10-00_524.gtm.ucl.ac.uk) which may not be permanent, but if we want to access the pre-prod server via the web, we need to fix some issues:
* Add hostname to nginx config server_name
* Add hostname to the self-signed cert
* Monkey patch Django so it'll allow hostnames containing underscores (otherwise you'll get Bad Request 400)

Related to #36