### PR TITLE
Fix/search ignore angle brackets

### DIFF
--- a/src/rard/research/views/search.py
+++ b/src/rard/research/views/search.py
@@ -81,10 +81,16 @@ class SearchView(LoginRequiredMixin, TemplateView, ListView):
             self.cleaned_number = 1
             self.folded_number = 1
             self.keywords = PUNCTUATION_RE.sub("", keywords).lower()
-            # The basic function query function will eliminate puntuation
+            # The basic function query function will first eliminate html less than
+            # and greater than character codes, then punctuation,
             # and lowercase the 'haystack' strings to be searched.
             self.basic_query = lambda q: Lower(
-                Func(q, Value(PUNCTUATION), Value(""), function="translate")
+                Func(
+                    Func(q, Value("&[gl]t;"), Value(""), function="regexp_replace"),
+                    Value(PUNCTUATION),
+                    Value(""),
+                    function="translate",
+                )
             )
             self.query = self.basic_query
             # Now we call add_fold repeatedly to add more

--- a/src/rard/research/views/work.py
+++ b/src/rard/research/views/work.py
@@ -124,7 +124,7 @@ class WorkDetailView(
         add_to_ordered_materials(apposita)
 
         context["ordered_materials"] = ordered_materials
-        return ordered_materials
+        return context
 
 
 def add_new_books_to_work(work, form):

--- a/src/rard/research/views/work.py
+++ b/src/rard/research/views/work.py
@@ -42,7 +42,8 @@ class WorkDetailView(
         books = work.book_set.all()
         # Empty structure with space for materials with unknown book
         ordered_materials = {
-            book: {"definite": [], "possible": []} for book in list(books) + ["unknown"]
+            book.__str__(): {"definite": [], "possible": []}
+            for book in list(books) + ["unknown"]
         }
 
         def inflate(query_list, pk_field, model, new_key):

--- a/src/rard/templates/research/work_detail.html
+++ b/src/rard/templates/research/work_detail.html
@@ -128,6 +128,61 @@
     <hr>
 
     <section>
+      <div class='d-flex justify-content-between mb-3'>
+        <div>
+          <h5>{% trans 'Books' %}</h5>
+        </div>
+      </div>
+      {% for book, material in ordered_materials.items %}
+        <h5>{{ book }}</h5>
+          {% if material.fragments %}
+            {% if material.fragments.definite %}
+              <h7>{% trans 'Definite Fragments' %}</h7>
+              {% for fragment in material.fragments.definite %}
+                {% include 'research/partials/fragment_list_item.html' with fragment=fragment %}
+              {% endfor %}
+            {% endif %}
+            {% if material.fragments.possible %}
+              <h7>{% trans 'Possible Fragments' %}</h7>
+              {% for fragment in material.fragments.possible %}
+                {% include 'research/partials/fragment_list_item.html' with fragment=fragment %}
+              {% endfor %}
+            {% endif %}
+          {% endif %}
+          {% if material.testimonia %}
+            {% if material.testimonia.definite %}
+              <h7>{% trans 'Definite Testimonia' %}</h7>
+              {% for testimonium in material.testimonia.definite %}
+                {% include 'research/partials/testimonium_list_item.html' with testimonium=testimonium %}
+              {% endfor %}
+            {% endif %}
+            {% if material.testimonia.possible %}
+              <h7>{% trans 'Possible Testimonia' %}</h7>
+              {% for testimonium in material.testimonia.possible %}
+                {% include 'research/partials/testimonium_list_item.html' with testimonium=testimonium %}
+              {% endfor %}
+            {% endif %}
+          {% endif %}
+          {% if material.apposita %}
+            {% if material.apposita.definite %}
+              <h7>{% trans 'Definite Apposita' %}</h7>
+              {% for appositum in material.apposita.definite %}
+                {% include 'research/partials/fragment_list_item.html' with fragment=appositum %}
+              {% endfor %}
+            {% endif %}
+            {% if material.apposita.possible %}
+              <h7>{% trans 'Possible Apposita' %}</h7>
+              {% for appositum in material.apposita.possible %}
+                {% include 'research/partials/fragment_list_item.html' with fragment=appositum %}
+              {% endfor %}
+            {% endif %}
+          {% endif %}
+      {% endfor %}
+    </section>
+
+    <hr>
+
+    <section>
         <div class='d-flex justify-content-between mb-3'>
             <div>
                 <h5>{% trans 'Definite Testimonia' %}</h5>


### PR DESCRIPTION
In #297 @rmamarshall pointed out angle brackets are not being ignored in search in the same way that other brackets are. This was due to <> being converted to their html character codes, "\&lt;" and "\&gt;", which were not then picked up by the translate function which strips out other forms of punctuation during the search.

I've added an additional query function to the basic query which uses postgres's regexp_replace method to remove these character codes prior to the rest of the punctuation characters being removed.