### PR TITLE
add query func to strip <> character codes

### DIFF
--- a/src/rard/research/views/search.py
+++ b/src/rard/research/views/search.py
@@ -86,7 +86,13 @@ class SearchView(LoginRequiredMixin, TemplateView, ListView):
             # and lowercase the 'haystack' strings to be searched.
             self.basic_query = lambda q: Lower(
                 Func(
-                    Func(q, Value("&[gl]t;"), Value(""), function="regexp_replace"),
+                    Func(
+                        q,
+                        Value("&[gl]t;"),
+                        Value(""),
+                        Value("g"),
+                        function="regexp_replace",
+                    ),
                     Value(PUNCTUATION),
                     Value(""),
                     function="translate",

--- a/src/rard/research/views/search.py
+++ b/src/rard/research/views/search.py
@@ -81,10 +81,16 @@ class SearchView(LoginRequiredMixin, TemplateView, ListView):
             self.cleaned_number = 1
             self.folded_number = 1
             self.keywords = PUNCTUATION_RE.sub("", keywords).lower()
-            # The basic function query function will eliminate puntuation
+            # The basic function query function will first eliminate html less than
+            # and greater than character codes, then punctuation,
             # and lowercase the 'haystack' strings to be searched.
             self.basic_query = lambda q: Lower(
-                Func(q, Value(PUNCTUATION), Value(""), function="translate")
+                Func(
+                    Func(q, Value("&[gl]t;"), Value(""), function="regexp_replace"),
+                    Value(PUNCTUATION),
+                    Value(""),
+                    function="translate",
+                )
             )
             self.query = self.basic_query
             # Now we call add_fold repeatedly to add more


### PR DESCRIPTION
In #297 @rmamarshall pointed out angle brackets are not being ignored in search in the same way that other brackets are. This was due to <> being converted to their html character codes, "&lt;" and "&gt;", which were not then picked up by the translate function which strips out other forms of punctuation during the search.

I've added an additional query function to the basic query which uses postgres's regexp_replace method to remove these character codes prior to the rest of the punctuation characters being removed.