### PR TITLE
Fix/display unlinked apposita

### DIFF
--- a/src/rard/templates/research/anonymousfragment_detail.html
+++ b/src/rard/templates/research/anonymousfragment_detail.html
@@ -233,6 +233,12 @@
                       {% include 'research/partials/appositum_links_list_item.html' with link=link can_edit=perms.research.change_anonymous_fragment has_object_lock=has_object_lock %}
                     {% endfor %}
 
+                    {% for fragment in object.fragments.all %}
+                      {% if fragment.is_unlinked %}
+                        {% include 'research/partials/fragment_list_item.html' with fragment=fragment %}
+                      {% endif %}
+                    {% endfor %}
+
                 {% endif %}
             </div>
         </div>

--- a/src/rard/templates/research/fragment_detail.html
+++ b/src/rard/templates/research/fragment_detail.html
@@ -304,6 +304,12 @@
             {% endif %}
         {% endfor %}
 
+        {% if object.is_unlinked %}
+          {% for appositum in object.apposita.all %}
+            {% include 'research/partials/anonymousfragment_list_item.html' with fragment=appositum %}
+          {% endfor %}
+        {% endif %}
+
     </section>
 
 


### PR DESCRIPTION
Making an anonymous fragment an appositum to an unlinked fragment does no create a fragment link object. The fragment and anonymous fragment detail pages weren't taking this into account as they were just looping through all fragment link objects to display apposita. This PR fixes both detail pages to include unlinked<->anonymous fragment apposita.
Related to #289 