### PR TITLE
Work fragments ordered by book

### DIFF
--- a/src/rard/research/models/work.py
+++ b/src/rard/research/models/work.py
@@ -121,3 +121,6 @@ class Book(HistoryModelMixin, DatedModel, BaseModel):
     def get_absolute_url(self):
         # link to its owning work
         return reverse("work:detail", kwargs={"pk": self.work.pk})
+
+    def get_display_string(self):
+        return self.__str__()

--- a/src/rard/research/models/work.py
+++ b/src/rard/research/models/work.py
@@ -1,6 +1,7 @@
 from django.contrib.postgres.aggregates import StringAgg
 from django.db import models
 from django.urls import reverse
+from django.utils.text import slugify
 from simple_history.models import HistoricalRecords
 
 from rard.research.models.mixins import HistoryModelMixin
@@ -122,5 +123,8 @@ class Book(HistoryModelMixin, DatedModel, BaseModel):
         # link to its owning work
         return reverse("work:detail", kwargs={"pk": self.work.pk})
 
-    def get_display_string(self):
+    def get_display_name(self):
         return self.__str__()
+
+    def get_anchor_id(self):
+        return slugify(self.__str__())

--- a/src/rard/research/views/work.py
+++ b/src/rard/research/views/work.py
@@ -118,8 +118,8 @@ class WorkDetailView(
         # Needs to be ordered by book then definite for make_grouped_dict to work
         fragments = list(
             work.antiquarian_work_fragmentlinks.values(
-                "definite", "book", pk=F("fragment__pk")
-            ).order_by("book", "-definite")
+                "definite", "book", "order", pk=F("fragment__pk")
+            ).order_by("book", "-definite", "order")
         )
         fragments = inflate(
             inflate(fragments, "pk", Fragment, "object"), "book", Book, "book"
@@ -130,8 +130,8 @@ class WorkDetailView(
         # Same for testimonia via work_testimoniumlinks
         testimonia = list(
             work.antiquarian_work_testimoniumlinks.values(
-                "definite", "book", pk=F("testimonium__pk")
-            ).order_by("book", "-definite")
+                "definite", "book", "order", pk=F("testimonium__pk")
+            ).order_by("book", "-definite", "order")
         )
         testimonia = inflate(
             inflate(testimonia, "pk", Testimonium, "object"), "book", Book, "book"
@@ -142,8 +142,8 @@ class WorkDetailView(
         # Finally for apposita
         apposita = list(
             work.antiquarian_work_appositumfragmentlinks.values(
-                "definite", "book", pk=F("anonymous_fragment__pk")
-            ).order_by("book", "-definite")
+                "definite", "book", "order", pk=F("anonymous_fragment__pk")
+            ).order_by("book", "-definite", "order")
         )
         apposita = inflate(
             inflate(apposita, "pk", AnonymousFragment, "object"), "book", Book, "book"

--- a/src/rard/research/views/work.py
+++ b/src/rard/research/views/work.py
@@ -124,7 +124,7 @@ class WorkDetailView(
         add_to_ordered_materials(apposita)
 
         context["ordered_materials"] = ordered_materials
-        return ordered_materials
+        return context
 
 
 def add_new_books_to_work(work, form):

--- a/src/rard/research/views/work.py
+++ b/src/rard/research/views/work.py
@@ -42,7 +42,8 @@ class WorkDetailView(
         books = work.book_set.all()
         # Empty structure with space for materials with unknown book
         ordered_materials = {
-            book: {"definite": [], "possible": []} for book in list(books) + ["unknown"]
+            book.__str__(): {"definite": [], "possible": []}
+            for book in list(books) + ["unknown"]
         }
 
         def inflate(query_list, pk_field, model, new_key):

--- a/src/rard/research/views/work.py
+++ b/src/rard/research/views/work.py
@@ -46,7 +46,7 @@ class WorkDetailView(
                 material: {"definite": [], "possible": []}
                 for material in ["fragments", "testimonia", "apposita"]
             }
-            for book in [b.get_anchor_id() for b in books] + ["Unknown Book"]
+            for book in list(books) + ["Unknown Book"]
         }
 
         def inflate(query_list, pk_field, model, new_key):
@@ -79,12 +79,12 @@ class WorkDetailView(
         def add_to_ordered_materials(grouped_dict, material_type):
             for book, materials in grouped_dict.items():
                 if book:
-                    ordered_materials[book.get_anchor_id()][material_type][
-                        "definite"
-                    ] += materials.get(True, [])
-                    ordered_materials[book.get_anchor_id()][material_type][
-                        "possible"
-                    ] += materials.get(False, [])
+                    ordered_materials[book][material_type]["definite"] += materials.get(
+                        True, []
+                    )
+                    ordered_materials[book][material_type]["possible"] += materials.get(
+                        False, []
+                    )
                 else:  # If book is None it's unknown
                     ordered_materials["Unknown Book"][material_type][
                         "definite"
@@ -146,16 +146,6 @@ class WorkDetailView(
         add_to_ordered_materials(apposita, "apposita")
 
         ordered_materials = remove_empty_books(ordered_materials)
-
-        # Add the display title so we can access it when looping through ordered
-        # materials (needs to happen after removing empty books)
-        for book in books:
-            if book.get_anchor_id() in ordered_materials:
-                ordered_materials[book.get_anchor_id()][
-                    "book_title"
-                ] = book.get_display_name()
-        if "Unknown Book" in ordered_materials:
-            ordered_materials["Unknown Book"]["book_title"] = "Unknown Book"
 
         context["ordered_materials"] = ordered_materials
         return context

--- a/src/rard/research/views/work.py
+++ b/src/rard/research/views/work.py
@@ -30,12 +30,18 @@ class WorkDetailView(
     def get_context_data(self, **kwargs):
         """Add a dictionary to context data called ordered materials.
         For each book in this work, add the book and a list of associated material
-        ordered by definite/possible boolean, then by material type; e.g.:
-        ordered_materials = {'book1': {'definite': [F1, T1, A1],
-                                       'possible': [F2, T2, A2]
-                                       },
-                             'book2': {...},
+        ordered by material type, then by definite/possible boolean; e.g.:
+        ordered_materials = {'book1': {
+                                'fragments':{
+                                    'definite':[F1,F2,F3],
+                                    'possible':[F4,F5,F6]},
+                                'testimonia':{
+                                    'definite':[T1,T2],
+                                    'possible':[T3,T4]
+                                },
+                                'apposita':{...}
                             }
+                        }
         """
         context = super().get_context_data(**kwargs)
         work = self.get_object()

--- a/src/rard/research/views/work.py
+++ b/src/rard/research/views/work.py
@@ -131,7 +131,6 @@ class WorkDetailView(
         add_to_ordered_materials(apposita, "apposita")
 
         context["ordered_materials"] = ordered_materials
-        print(ordered_materials)
         return context
 
 

--- a/src/rard/templates/research/work_detail.html
+++ b/src/rard/templates/research/work_detail.html
@@ -134,8 +134,8 @@
         </div>
       </div>
       {% for book, material in ordered_materials.items %}
-        <h5>{{ book }}</h5>
-          {% if material.fragments %}
+        {% if material.fragments.definite or material.fragments.possible %}
+          <h5>{{ book }}</h5>
             {% if material.fragments.definite %}
               <h7>{% trans 'Definite Fragments' %}</h7>
               {% for fragment in material.fragments.definite %}
@@ -176,7 +176,7 @@
                 {% include 'research/partials/fragment_list_item.html' with fragment=appositum %}
               {% endfor %}
             {% endif %}
-          {% endif %}
+        {% endif %}
       {% endfor %}
     </section>
 

--- a/src/rard/templates/research/work_detail.html
+++ b/src/rard/templates/research/work_detail.html
@@ -134,13 +134,8 @@
     <hr>
 
     <section>
-      <div class='d-flex justify-content-between mb-3'>
-        <div>
-          <h5>{% trans 'Books' %}</h5>
-        </div>
-      </div>
       {% for book, content in ordered_materials.items %}
-          <div id="{{ book.get_anchor_id }}">
+          <div id="{{ book.get_anchor_id }}" class="pb-4">
             <h5>{{ book }}</h5>
             {% if content.fragments.definite %}
               <h7>{% trans 'Definite Fragments' %}</h7>
@@ -172,90 +167,18 @@
               {% if content.apposita.definite %}
                 <h7>{% trans 'Definite Apposita' %}</h7>
                 {% for appositum in content.apposita.definite %}
-                  {% include 'research/partials/fragment_list_item.html' with fragment=appositum %}
+                  {% include 'research/partials/anonymousfragment_list_item.html' with fragment=appositum %}
                 {% endfor %}
               {% endif %}
               {% if content.apposita.possible %}
                 <h7>{% trans 'Possible Apposita' %}</h7>
                 {% for appositum in content.apposita.possible %}
-                  {% include 'research/partials/fragment_list_item.html' with fragment=appositum %}
+                  {% include 'research/partials/anonymousfragment_list_item.html' with fragment=appositum %}
                 {% endfor %}
               {% endif %}
             {% endif %}
           </div>
       {% endfor %}
-    </section>
-
-    <hr>
-
-    <section>
-        <div class='d-flex justify-content-between mb-3'>
-            <div>
-                <h5>{% trans 'Definite Testimonia' %}</h5>
-            </div>
-            <div>
-            </div>
-        </div>
-
-        {% for testimonium in object.definite_testimonia.all %}
-
-        {% include 'research/partials/testimonium_list_item.html' with testimonium=testimonium %}
-
-        {% endfor %}
-    </section>
-
-    <hr>
-
-    <section>
-        <div class='d-flex justify-content-between mb-3'>
-            <div>
-                <h5>{% trans 'Possible Testimonia' %}</h5>
-            </div>
-            <div>
-            </div>
-        </div>
-
-        {% for testimonium in object.possible_testimonia.all %}
-
-        {% include 'research/partials/testimonium_list_item.html' with testimonium=testimonium %}
-
-        {% endfor %}
-    </section>
-
-    <hr>
-
-    <section>
-        <div class='d-flex justify-content-between mb-3'>
-            <div>
-                <h5>{% trans 'Definite Fragments' %}</h5>
-            </div>
-            <div>
-            </div>
-        </div>
-
-        {% for fragment in object.definite_fragments.all %}
-
-        {% include 'research/partials/fragment_list_item.html' with fragment=fragment %}
-
-        {% endfor %}
-    </section>
-
-    <hr>
-
-    <section>
-        <div class='d-flex justify-content-between mb-3'>
-            <div>
-                <h5>{% trans 'Possible Fragments' %}</h5>
-            </div>
-            <div>
-            </div>
-        </div>
-
-        {% for fragment in object.possible_fragments.all %}
-
-        {% include 'research/partials/fragment_list_item.html' with fragment=fragment %}
-
-        {% endfor %}
     </section>
 
 
@@ -288,55 +211,6 @@
             {% endwith %}
 
     </section>
-
-
-    {% comment %}
-        <hr>
-
-
-    <section>
-        <div class='d-flex justify-content-between mb-3'>
-            <div>
-                <h5>{% trans 'Ordered Material' %}</h5>
-            </div>
-            <div>
-            </div>
-        </div>
-
-        <ul>
-            <div class='ordered-list'>
-            {% with tlinks=object.antiquarian_work_testimoniumlinks.all %}
-            {% with flinks=object.antiquarian_work_fragmentlinks.all %}
-            {% with alinks=object.antiquarian_work_appositumfragmentlinks.all %}
-
-                {% for link in tlinks %}
-                    {% include 'research/partials/testimonium_link_list_item.html' with link=link link_text=link.get_work_display_name_full|safe can_edit=perms.research.change_work has_object_lock=has_object_lock %}
-                {% endfor %}
-
-                {% for link in flinks %}
-                    {% include 'research/partials/fragment_link_list_item.html' with link=link  link_text=link.get_work_display_name_full|safe can_edit=perms.research.change_work has_object_lock=has_object_lock %}
-                {% endfor %}
-
-                {% for link in alinks %}
-                    {% include 'research/partials/appositum_fragment_link_list_item.html' with link=link link_text=link.get_work_display_name_full|safe can_edit=perms.research.change_work has_object_lock=has_object_lock %}
-                {% endfor %}
-
-                {% if not flinks and not tlinks and not alinks %}
-                <div class='text-muted my-3 ml-4'><em>No linked material for this work</em></div>
-                {% endif %}
-
-            {% endwith %}
-            {% endwith %}
-            {% endwith %}
-            </div>
-        </ul>
-
-
-
-
-    </section>
-
-    {% endcomment %}
 
     {% endwith %}
 {% endblock %}

--- a/src/rard/templates/research/work_detail.html
+++ b/src/rard/templates/research/work_detail.html
@@ -75,12 +75,13 @@
             <dd class="col-sm-9">
 
             {% for book in object.book_set.all %}
+              {% with book_name=book.get_anchor_id %}
                 <div class='d-flex justify-content-between mb-3'>
                     <div>
-                      {% if book.get_display_string in ordered_materials %}
-                      <a href="#book{{forloop.counter}}">{{book}}</a>
+                      {% if book_name in ordered_materials.keys %}
+                      <a href="#{{book.get_anchor_id}}">{{book}}</a>
                       {% else %}
-                      {{ book }}
+                        {{ book }}
                       {% endif %}
                       <br><small>{{ book.display_date_range }}</small></div>
                     <div>
@@ -99,6 +100,7 @@
                         </form>
                     </div>
                 </div>
+              {% endwith %}
             {% endfor %}
             </dd>
 
@@ -139,52 +141,50 @@
           <h5>{% trans 'Books' %}</h5>
         </div>
       </div>
-      {% for book, material in ordered_materials.items %}
-        {% if material.fragments.definite or material.fragments.possible %}
-          <div id="book{{forloop.counter}}">
-            <h5>{{ book }}</h5>
-            {% if material.fragments.definite %}
+      {% for book, content in ordered_materials.items %}
+          <div id="{{book}}">
+            <h5>{{ content.book_title }}</h5>
+            {% if content.fragments.definite %}
               <h7>{% trans 'Definite Fragments' %}</h7>
-              {% for fragment in material.fragments.definite %}
+              {% for fragment in content.fragments.definite %}
                 {% include 'research/partials/fragment_list_item.html' with fragment=fragment %}
               {% endfor %}
             {% endif %}
-            {% if material.fragments.possible %}
+            {% if content.fragments.possible %}
               <h7>{% trans 'Possible Fragments' %}</h7>
-              {% for fragment in material.fragments.possible %}
+              {% for fragment in content.fragments.possible %}
                 {% include 'research/partials/fragment_list_item.html' with fragment=fragment %}
               {% endfor %}
             {% endif %}
-            {% if material.testimonia %}
-              {% if material.testimonia.definite %}
+            {% if content.testimonia %}
+              {% if content.testimonia.definite %}
                 <h7>{% trans 'Definite Testimonia' %}</h7>
-                {% for testimonium in material.testimonia.definite %}
+                {% for testimonium in content.testimonia.definite %}
                   {% include 'research/partials/testimonium_list_item.html' with testimonium=testimonium %}
                 {% endfor %}
               {% endif %}
-              {% if material.testimonia.possible %}
+              {% if content.testimonia.possible %}
                 <h7>{% trans 'Possible Testimonia' %}</h7>
-                {% for testimonium in material.testimonia.possible %}
+                {% for testimonium in content.testimonia.possible %}
                   {% include 'research/partials/testimonium_list_item.html' with testimonium=testimonium %}
                 {% endfor %}
               {% endif %}
             {% endif %}
-            {% if material.apposita %}
-              {% if material.apposita.definite %}
+            {% if content.apposita %}
+              {% if content.apposita.definite %}
                 <h7>{% trans 'Definite Apposita' %}</h7>
-                {% for appositum in material.apposita.definite %}
+                {% for appositum in content.apposita.definite %}
                   {% include 'research/partials/fragment_list_item.html' with fragment=appositum %}
                 {% endfor %}
               {% endif %}
-              {% if material.apposita.possible %}
+              {% if content.apposita.possible %}
                 <h7>{% trans 'Possible Apposita' %}</h7>
-                {% for appositum in material.apposita.possible %}
+                {% for appositum in content.apposita.possible %}
                   {% include 'research/partials/fragment_list_item.html' with fragment=appositum %}
                 {% endfor %}
               {% endif %}
             {% endif %}
           </div>
-        {% endif %}
       {% endfor %}
     </section>
 

--- a/src/rard/templates/research/work_detail.html
+++ b/src/rard/templates/research/work_detail.html
@@ -128,6 +128,61 @@
     <hr>
 
     <section>
+      <div class='d-flex justify-content-between mb-3'>
+        <div>
+          <h5>{% trans 'Books' %}</h5>
+        </div>
+      </div>
+      {% for book, material in ordered_materials.items %}
+        <h5>{{ book }}</h5>
+          {% if material.fragments %}
+            {% if material.fragments.definite %}
+              <h7>{% trans 'Definite Fragments' %}</h7>
+              {% for fragment in material.fragments.definite %}
+                {% include 'research/partials/fragment_list_item.html' with fragment=fragment %}
+              {% endfor %}
+            {% endif %}
+            {% if material.fragments.possible %}
+              <h7>{% trans 'Possible Fragments' %}</h7>
+              {% for fragment in material.fragments.possible %}
+                {% include 'research/partials/fragment_list_item.html' with fragment=fragment %}
+              {% endfor %}
+            {% endif %}
+          {% endif %}
+          {% if material.testimonia %}
+            {% if material.testimonia.definite %}
+              <h7>{% trans 'Definite Testimonia' %}</h7>
+              {% for testimonium in material.testimonia.definite %}
+                {% include 'research/partials/testimonium_list_item.html' with testimonium=testimonium %}
+              {% endfor %}
+            {% endif %}
+            {% if material.testimonia.possible %}
+              <h7>{% trans 'Possible Testimonia' %}</h7>
+              {% for testimonium in material.testimonia.possible %}
+                {% include 'research/partials/testimonium_list_item.html' with testimonium=testimonium %}
+              {% endfor %}
+            {% endif %}
+          {% endif %}
+          {% if material.apposita %}
+            {% if material.apposita.definite %}
+              <h7>{% trans 'Definite Apposita' %}</h7>
+              {% for appositum in material.apposita.definite %}
+                {% include 'research/partials/fragment_list_item.html' with fragment=appositum %}
+              {% endfor %}
+            {% endif %}
+            {% if material.apposita.possible %}
+              <h7>{% trans 'Possible Apposita' %}</h7>
+              {% for appositum in material.apposita.possible %}
+                {% include 'research/partials/fragment_list_item.html' with fragment=appositum %}
+              {% endfor %}
+            {% endif %}
+          {% endif %}
+      {% endfor %}
+    </section>
+
+    <hr>
+
+    <section>
         <div class='d-flex justify-content-between mb-3'>
             <div>
                 <h5>{% trans 'Definite Testimonia' %}</h5>

--- a/src/rard/templates/research/work_detail.html
+++ b/src/rard/templates/research/work_detail.html
@@ -74,43 +74,41 @@
             <dt class="col-sm-3">{% trans 'Books' %}</dt>
             <dd class="col-sm-9">
 
-            {% for book in object.book_set.all %}
-              {% with book_name=book.get_anchor_id %}
+              {% for book in object.book_set.all %}
                 <div class='d-flex justify-content-between mb-3'>
-                    <div>
-                      {% if book_name in ordered_materials.keys %}
+                  <div>
+                    {% if book in ordered_materials %}
                       <a href="#{{book.get_anchor_id}}">{{book}}</a>
-                      {% else %}
-                        {{ book }}
-                      {% endif %}
-                      <br><small>{{ book.display_date_range }}</small></div>
-                    <div>
-                        <form novalidate class='form-inline' action='{% url "work:delete_book" book.pk %}' method='POST'>
-                            {% csrf_token %}
-                            <div class='form-row align-items-center'>
-                                {% if perms.research.change_work and perms.research.change_book and has_object_lock %}
-                                <a href='{% url "work:update_book" book.pk %}'>Edit</a>
-                                {% endif %}
-                                {% if perms.research.change_work and perms.research.delete_book and has_object_lock %}
-                                <button type='submit' class='btn btn-link text-danger confirm-delete p-0 ml-2'
-                                    data-what='book'>{% trans 'Delete' %}</button>
-                                {% endif %}
-                                <a class='ml-2' href='{{ book.history_url }}'><small><i class='fas fa-list'></i> Changelog</small></a>
-                            </div>
-                        </form>
-                    </div>
+                    {% else %}
+                      {{ book }}
+                    {% endif %}
+                    <br><small>{{ book.display_date_range }}</small></div>
+                  <div>
+                    <form novalidate class='form-inline' action='{% url "work:delete_book" book.pk %}' method='POST'>
+                      {% csrf_token %}
+                      <div class='form-row align-items-center'>
+                        {% if perms.research.change_work and perms.research.change_book and has_object_lock %}
+                          <a href='{% url "work:update_book" book.pk %}'>Edit</a>
+                        {% endif %}
+                        {% if perms.research.change_work and perms.research.delete_book and has_object_lock %}
+                          <button type='submit' class='btn btn-link text-danger confirm-delete p-0 ml-2'
+                              data-what='book'>{% trans 'Delete' %}</button>
+                        {% endif %}
+                        <a class='ml-2' href='{{ book.history_url }}'><small><i class='fas fa-list'></i> Changelog</small></a>
+                      </div>
+                    </form>
+                  </div>
                 </div>
-              {% endwith %}
-            {% endfor %}
+              {% endfor %}
             </dd>
 
             {% endif %}
         </dl>
 
         <p>
-            <small>
-            {% include 'research/partials/render_last_modified_info.html' with object=object %}
-            </small>
+          <small>
+          {% include 'research/partials/render_last_modified_info.html' with object=object %}
+          </small>
         </p>
 
     </section>
@@ -142,8 +140,8 @@
         </div>
       </div>
       {% for book, content in ordered_materials.items %}
-          <div id="{{book}}">
-            <h5>{{ content.book_title }}</h5>
+          <div id="{{ book.get_anchor_id }}">
+            <h5>{{ book }}</h5>
             {% if content.fragments.definite %}
               <h7>{% trans 'Definite Fragments' %}</h7>
               {% for fragment in content.fragments.definite %}

--- a/src/rard/templates/research/work_detail.html
+++ b/src/rard/templates/research/work_detail.html
@@ -76,7 +76,13 @@
 
             {% for book in object.book_set.all %}
                 <div class='d-flex justify-content-between mb-3'>
-                    <div>{{ book }}<br><small>{{ book.display_date_range }}</small></div>
+                    <div>
+                      {% if book.get_display_string in ordered_materials %}
+                      <a href="#book{{forloop.counter}}">{{book}}</a>
+                      {% else %}
+                      {{ book }}
+                      {% endif %}
+                      <br><small>{{ book.display_date_range }}</small></div>
                     <div>
                         <form novalidate class='form-inline' action='{% url "work:delete_book" book.pk %}' method='POST'>
                             {% csrf_token %}
@@ -135,7 +141,8 @@
       </div>
       {% for book, material in ordered_materials.items %}
         {% if material.fragments.definite or material.fragments.possible %}
-          <h5>{{ book }}</h5>
+          <div id="book{{forloop.counter}}">
+            <h5>{{ book }}</h5>
             {% if material.fragments.definite %}
               <h7>{% trans 'Definite Fragments' %}</h7>
               {% for fragment in material.fragments.definite %}
@@ -148,34 +155,35 @@
                 {% include 'research/partials/fragment_list_item.html' with fragment=fragment %}
               {% endfor %}
             {% endif %}
-          {% endif %}
-          {% if material.testimonia %}
-            {% if material.testimonia.definite %}
-              <h7>{% trans 'Definite Testimonia' %}</h7>
-              {% for testimonium in material.testimonia.definite %}
-                {% include 'research/partials/testimonium_list_item.html' with testimonium=testimonium %}
-              {% endfor %}
+            {% if material.testimonia %}
+              {% if material.testimonia.definite %}
+                <h7>{% trans 'Definite Testimonia' %}</h7>
+                {% for testimonium in material.testimonia.definite %}
+                  {% include 'research/partials/testimonium_list_item.html' with testimonium=testimonium %}
+                {% endfor %}
+              {% endif %}
+              {% if material.testimonia.possible %}
+                <h7>{% trans 'Possible Testimonia' %}</h7>
+                {% for testimonium in material.testimonia.possible %}
+                  {% include 'research/partials/testimonium_list_item.html' with testimonium=testimonium %}
+                {% endfor %}
+              {% endif %}
             {% endif %}
-            {% if material.testimonia.possible %}
-              <h7>{% trans 'Possible Testimonia' %}</h7>
-              {% for testimonium in material.testimonia.possible %}
-                {% include 'research/partials/testimonium_list_item.html' with testimonium=testimonium %}
-              {% endfor %}
+            {% if material.apposita %}
+              {% if material.apposita.definite %}
+                <h7>{% trans 'Definite Apposita' %}</h7>
+                {% for appositum in material.apposita.definite %}
+                  {% include 'research/partials/fragment_list_item.html' with fragment=appositum %}
+                {% endfor %}
+              {% endif %}
+              {% if material.apposita.possible %}
+                <h7>{% trans 'Possible Apposita' %}</h7>
+                {% for appositum in material.apposita.possible %}
+                  {% include 'research/partials/fragment_list_item.html' with fragment=appositum %}
+                {% endfor %}
+              {% endif %}
             {% endif %}
-          {% endif %}
-          {% if material.apposita %}
-            {% if material.apposita.definite %}
-              <h7>{% trans 'Definite Apposita' %}</h7>
-              {% for appositum in material.apposita.definite %}
-                {% include 'research/partials/fragment_list_item.html' with fragment=appositum %}
-              {% endfor %}
-            {% endif %}
-            {% if material.apposita.possible %}
-              <h7>{% trans 'Possible Apposita' %}</h7>
-              {% for appositum in material.apposita.possible %}
-                {% include 'research/partials/fragment_list_item.html' with fragment=appositum %}
-              {% endfor %}
-            {% endif %}
+          </div>
         {% endif %}
       {% endfor %}
     </section>


### PR DESCRIPTION
Fix for #160 
I've added a get_context_data function to the WorkDetailView which passes a nested dictionary containing the work's books, their fragments, testimonia, and apposita, and separate lists for definite and possible links.
The work detail template loops through these dictionaries to display associated material ordered by book, then by material type (fragment, testimonium, appositum), then by definite/possible.
I've also added anchor links to help navigate from book titles in the details section to the area of the page listing that book's contents.