### PR TITLE
Feature/include unlinked in mentions

### DIFF
--- a/src/rard/research/tests/views/test_mentions.py
+++ b/src/rard/research/tests/views/test_mentions.py
@@ -131,6 +131,11 @@ class TestMentionsView(TestCase):
         self.assertEqual(list(view.work_search("NothInG")), [w2])
         self.assertEqual(list(view.work_search("O")), [w2, w1])
 
+        # unlinked fragments
+        f56 = Fragment.objects.create(id=56)
+        f523 = Fragment.objects.create(id=523)
+        self.assertEqual(list(view.unlinked_fragment_search("u5")), [f56, f523])
+
         # fragments
         f1 = Fragment.objects.create()
         FragmentLink.objects.create(fragment=f1, antiquarian=a1)

--- a/src/rard/research/views/mention.py
+++ b/src/rard/research/views/mention.py
@@ -35,6 +35,7 @@ class MentionSearchView(LoginRequiredMixin, View):
             "topics": self.topic_search,
             "works": self.work_search,
             "bibliographies": self.bibliography_search,
+            "unlinked fragments": self.unlinked_fragment_search,
         }
 
     # move to queryset on model managers
@@ -73,6 +74,19 @@ class MentionSearchView(LoginRequiredMixin, View):
             return keywords[1:]
         keywords[0] = k
         return keywords
+
+    @classmethod
+    def unlinked_fragment_search(cls, keywords):
+        qs = Fragment.objects.filter(antiquarian_fragmentlinks=None)
+        kws = keywords.split()
+        ids = cls.remove_keyword("u", kws)
+        if ids is None or 1 < len(ids):
+            return qs.none()
+        if len(ids) == 0:
+            return qs
+        if not ids[0].isnumeric():
+            return qs.none()
+        return qs.filter(id__startswith=int(ids[0]))
 
     @classmethod
     def anonymous_fragment_search(cls, keywords):


### PR DESCRIPTION
Addressing #295, unlinked fragments can now be added via @ mentions. This works in a similar fashion to anonymous fragments search in that a keyword consisting of the letter "u" will find all unlinked fragments, and "u\<int\>" will find all unlinked fragments whose id starts with that number; e.g. "u33" will find Unlinked 338 and Unlinked 339.