### PR TITLE
Distinguish development server emails from prod

### DIFF
--- a/src/config/settings/development.py
+++ b/src/config/settings/development.py
@@ -103,7 +103,7 @@ DEFAULT_FROM_EMAIL = env(
 SERVER_EMAIL = env("DJANGO_SERVER_EMAIL", default=DEFAULT_FROM_EMAIL)
 # https://docs.djangoproject.com/en/dev/ref/settings/#email-subject-prefix
 EMAIL_SUBJECT_PREFIX = env(
-    "DJANGO_EMAIL_SUBJECT_PREFIX", 
+    "DJANGO_EMAIL_SUBJECT_PREFIX",
     default="[Republican Antiquarians Research Database (dev)]",
 )
 

--- a/src/config/settings/development.py
+++ b/src/config/settings/development.py
@@ -97,13 +97,13 @@ TEMPLATES[-1]["OPTIONS"]["loaders"] = [  # type: ignore[index] # noqa F405
 # https://docs.djangoproject.com/en/dev/ref/settings/#default-from-email
 DEFAULT_FROM_EMAIL = env(
     "DJANGO_DEFAULT_FROM_EMAIL",
-    default="Republican Antiquarians Research Database <noreply@example.com>",
+    default="Republican Antiquarians Research Database (dev) <noreply@example.com>",
 )
 # https://docs.djangoproject.com/en/dev/ref/settings/#server-email
 SERVER_EMAIL = env("DJANGO_SERVER_EMAIL", default=DEFAULT_FROM_EMAIL)
 # https://docs.djangoproject.com/en/dev/ref/settings/#email-subject-prefix
 EMAIL_SUBJECT_PREFIX = env(
-    "DJANGO_EMAIL_SUBJECT_PREFIX", default="[Republican Antiquarians Research Database]"
+    "DJANGO_EMAIL_SUBJECT_PREFIX", default="[Republican Antiquarians Research Database (dev)]"
 )
 
 # ADMIN

--- a/src/config/settings/development.py
+++ b/src/config/settings/development.py
@@ -103,7 +103,8 @@ DEFAULT_FROM_EMAIL = env(
 SERVER_EMAIL = env("DJANGO_SERVER_EMAIL", default=DEFAULT_FROM_EMAIL)
 # https://docs.djangoproject.com/en/dev/ref/settings/#email-subject-prefix
 EMAIL_SUBJECT_PREFIX = env(
-    "DJANGO_EMAIL_SUBJECT_PREFIX", default="[Republican Antiquarians Research Database (dev)]"
+    "DJANGO_EMAIL_SUBJECT_PREFIX", 
+    default="[Republican Antiquarians Research Database (dev)]",
 )
 
 # ADMIN


### PR DESCRIPTION
Tweaking the config so that emails from the development (preprod) server have a different from email address and subject line.