### PR TITLE
Fix/broken link emails

### DIFF
--- a/src/compose/development/nginx/conf.d/rard.conf
+++ b/src/compose/development/nginx/conf.d/rard.conf
@@ -6,7 +6,7 @@ upstream django {
 server {
     listen 80;
 
-    server_name www.ucl.ac.uk frra-app01p.ad.ucl.ac.uk frra-pp-10-00_524.gtm.ucl.ac.uk;
+    server_name www.ucl.ac.uk;
 
     # Permanent HTTPS redirect
     #return 302 https://$server_name$request_uri;
@@ -31,6 +31,11 @@ server {
         add_header X-Proxy $hostname;
         add_header X-Upstream $upstream_addr;
     }
+
+    # Reject any requests we don't expect
+    location ~ ^\/(?!(history\/frrant-preprod|favicon\.ico)).* {
+        return 403;
+    }
 }
 
 # Django app over HTTPS
@@ -40,7 +45,7 @@ server {
     include /etc/nginx/snippets/certificates.conf;
     include /etc/nginx/snippets/ssl-params.conf;
 
-    server_name www.ucl.ac.uk frra-app01p.ad.ucl.ac.uk frra-pp-10-00_524.gtm.ucl.ac.uk;
+    server_name www.ucl.ac.uk;
 
     location = /favicon.ico { access_log off; log_not_found off; }
     location /history/frrant-preprod/static/ {
@@ -60,5 +65,10 @@ server {
         # Tell Django that this was originally a secure request so
         # that it does not try to redirect infinitely
         proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Reject any requests we don't expect
+    location ~ ^\/(?!(history\/frrant-preprod|favicon\.ico)).* {
+        return 403;
     }
 }

--- a/src/compose/production/nginx/conf.d/rard.conf
+++ b/src/compose/production/nginx/conf.d/rard.conf
@@ -31,6 +31,11 @@ server {
         add_header X-Proxy $hostname;
         add_header X-Upstream $upstream_addr;
     }
+
+    # Reject any requests we don't expect
+    location ~ ^\/(?!(history\/frrant|favicon\.ico)).* {
+        return 403;
+    }
 }
 
 # Django app over HTTPS
@@ -65,6 +70,11 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Reject any requests we don't expect
+    location ~ ^\/(?!(history\/frrant|favicon\.ico|pgadmin4)).* {
+        return 403;
     }
 }
 


### PR DESCRIPTION
This should stop the broken link emails coming from production. This change tells nginx to reject any request that don't match /history/frrant/* or favicon.ico, or pgadmin4 (whatever that is).