### PR TITLE
Fix/make anonymous order

### DIFF
--- a/src/.pre-commit-config.yaml
+++ b/src/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-yaml
 
   - repo: https://github.com/psf/black
-    rev: 21.8b0
+    rev: 22.3.0
     hooks:
       - id: black
 

--- a/src/.pre-commit-config.yaml
+++ b/src/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-yaml
 
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: stable
     hooks:
       - id: black
 

--- a/src/rard/research/tests/views/test_fragment.py
+++ b/src/rard/research/tests/views/test_fragment.py
@@ -262,3 +262,15 @@ class TestFragmentConvertViews(TestCase):
         )
         self.assertEqual(new_fragment.date_range, "509 BCE - 31 BCE")
         self.assertEqual(new_fragment.commentary.content, "hello")
+
+    def test_converted_unlinked_has_correct_order(self):
+        """Make sure newly created anonymous fragment has the correct order
+        value."""
+        ufr_topic = Topic.objects.get(name="ufr topic")
+        ufr_topic.move_to(0)  # Give unlinked fragment's topic first place
+        new_fragment = convert_unlinked_fragment_to_anonymous_fragment(
+            self.unlinked_fragment
+        )
+        new_fragment.save()
+        self.assertEqual(ufr_topic.order, 0)
+        self.assertEqual(new_fragment.order, 0)

--- a/src/rard/utils/convertors.py
+++ b/src/rard/utils/convertors.py
@@ -1,5 +1,6 @@
 from rard.research.models import AnonymousFragment, Fragment
 from rard.research.models.base import FragmentLink
+from rard.research.models.fragment import reindex_anonymous_fragments
 
 
 class FragmentIsNotConvertible(Exception):
@@ -60,7 +61,8 @@ def convert_unlinked_fragment_to_anonymous_fragment(fragment):
     transfer_data_between_fragments(fragment, anonymous_fragment)
     anonymous_fragment.save()
     fragment.delete()
-
+    reindex_anonymous_fragments()
+    anonymous_fragment.refresh_from_db()
     return anonymous_fragment
 
 


### PR DESCRIPTION
closes #309 
Anonymous fragments needed to be reindexed after an unlinked fragment is made anonymous. Reindexing removes any collisions caused by two anon fragments having the same order value.