### PR TITLE
Fix/missing_frags_on_work_detail

### DIFF
--- a/src/.pre-commit-config.yaml
+++ b/src/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-yaml
 
   - repo: https://github.com/psf/black
-    rev: 21.8b0
+    rev: 22.3.0
     hooks:
       - id: black
 

--- a/src/rard/research/views/work.py
+++ b/src/rard/research/views/work.py
@@ -76,10 +76,10 @@ class WorkDetailView(
                           {'book':'book1','definite'true','object':F5},
                           {'book':'book1','definite'false','object':F6}]
             grouped_dict = {'book1': {'true': [F1,F3,F5],'false':[F2,F4,F6]}}"""
-            grouped_dict = {
-                k[0]: {k[1]: [f["object"] for f in v]}
-                for k, v in groupby(query_list, lambda x: [x["book"], x["definite"]])
-            }
+            grouped_dict = {}
+            for k, v in groupby(query_list, lambda x: [x["book"], x["definite"]]):
+                grouped_dict.setdefault(k[0], {})
+                grouped_dict[k[0]][k[1]] = [f["object"] for f in v]
             return grouped_dict
 
         def add_to_ordered_materials(grouped_dict, material_type):


### PR DESCRIPTION
closes #325 missing fragments on citing work pages.

The problem was in the make_grouped_dict function which was overwriting lists of definite fragments if possible fragments existed.