### PR TITLE
Fix for citing_work_reference_display

### DIFF
--- a/src/rard/research/models/original_text.py
+++ b/src/rard/research/models/original_text.py
@@ -81,8 +81,8 @@ class OriginalText(HistoryModelMixin, BaseModel):
 
     def citing_work_reference_display(self):
         citing_work_str = str(self.citing_work)
-        if self.reference:
-            citing_work_str = " ".join([citing_work_str, self.reference])
+        if self.references:
+            citing_work_str = " ".join([citing_work_str, self.reference_list])
         return citing_work_str
 
     def index_with_respect_to_parent_object(self):


### PR DESCRIPTION
The citing_work_reference_display method on fragments etc. was broken because reference no longer existed as a property on original texts. Instead we now use the newly created reference_list property