### PR TITLE
Ensure original texts have at least one reference

### DIFF
--- a/src/rard/research/forms.py
+++ b/src/rard/research/forms.py
@@ -609,7 +609,10 @@ ReferenceFormset = inlineformset_factory(
     fields=("editor", "reference_position"),
     labels={"editor": "Editor", "reference_position": "Reference"},
     can_delete=True,
-    extra=1,
+    min_num=1,
+    validate_min=True,
+    extra=0,
+    error_messages={"too_few_forms": "Please add at least one reference"},
 )
 
 

--- a/src/rard/research/tests/views/test_original_text.py
+++ b/src/rard/research/tests/views/test_original_text.py
@@ -290,3 +290,31 @@ class TestReferences(TestCase):
 
         self.assertEqual(1, originaltext.references.count())
         self.assertEqual(originaltext.references.first().reference_position, "1.2.3")
+
+    def test_at_least_one_reference(self):
+        # data for both original text and fragment
+        # but without any references
+        data = {
+            "apparatus_criticus": "app_criticus",
+            "content": "content",
+            "reference_order": 1,
+            "citing_work": self.citing_work.pk,
+            "citing_author": self.citing_work.author.pk,
+            "create_object": True,
+            "references-TOTAL_FORMS": 1,
+            "references-INITIAL_FORMS": 0,
+            "references-MIN_NUM_FORMS": 0,
+            "references-MAX_NUM_FORMS": 1000,
+        }
+
+        # assert no original texts initially
+        self.assertEqual(0, OriginalText.objects.count())
+
+        request = RequestFactory().post("/", data=data)
+        request.user = UserFactory.create()
+
+        FragmentCreateView.as_view()(
+            request,
+        )
+        self.assertEqual(0, Fragment.objects.count())
+        self.assertEqual(0, OriginalText.objects.count())

--- a/src/rard/templates/research/base_create_form.html
+++ b/src/rard/templates/research/base_create_form.html
@@ -34,8 +34,6 @@
 
         {% if citing_author and citing_work %}
 
-
-
             {% include 'research/partials/reference_form.html' %}
 
             {% bootstrap_field forms.original_text.reference_order field_class='d-flex' %}

--- a/src/rard/templates/research/partials/reference_form.html
+++ b/src/rard/templates/research/partials/reference_form.html
@@ -4,6 +4,7 @@
 
 {{ forms.references.management_form }}
 <legend style="font-family:alphabetum; font-size:large">References</legend>
+{% bootstrap_formset_errors forms.references %}
 
 <div id="reference-form-area" class="pr-3">
   {% for form in forms.references %}


### PR DESCRIPTION
Changes to reference formset settings to ensure original texts always have at least one reference.