### PR TITLE
Fix/cannot-create-original-text

### DIFF
--- a/src/rard/research/tests/forms/test_references.py
+++ b/src/rard/research/tests/forms/test_references.py
@@ -1,0 +1,85 @@
+import pytest
+from django.test import TestCase
+
+from rard.research.forms import ReferenceFormset
+from rard.research.models import CitingWork, Fragment, OriginalText, Reference
+
+pytestmark = pytest.mark.django_db
+
+
+class TestReferenceFormset(TestCase):
+    def setUp(self):
+        self.fragment = Fragment.objects.create(name="name")
+        self.citing_work = CitingWork.objects.create(title="title")
+        ot_data = {
+            "content": "content",
+            "citing_work": self.citing_work,
+            "owner": self.fragment,
+        }
+        self.original_text = OriginalText.objects.create(**ot_data)
+        self.reference1 = Reference.objects.create(
+            original_text=self.original_text,
+            editor="Romulus",
+            reference_position="1.2.3",
+        )
+        self.reference2 = Reference.objects.create(
+            original_text=self.original_text, editor="Remus", reference_position="4.5.6"
+        )
+
+    def test_reference_formset_initial_values(self):
+        formset = ReferenceFormset(instance=self.original_text)
+        # formset should include forms for both existing references
+        initial_data = [form.initial for form in formset.forms]
+        ref1_expected = {
+            "editor": "Romulus",
+            "reference_position": "1.2.3",
+            "original_text": self.original_text.id,
+        }
+        ref2_expected = {
+            "editor": "Remus",
+            "reference_position": "4.5.6",
+            "original_text": self.original_text.id,
+        }
+        self.assertIn(ref1_expected, initial_data)
+        self.assertIn(ref2_expected, initial_data)
+
+    def test_reference_formset_create(self):
+        # Confirm there are two references initially
+        self.assertEqual(self.original_text.references.count(), 2)
+
+        # Create another reference attached to the original text
+        data = {
+            "references-TOTAL_FORMS": 1,
+            "references-INITIAL_FORMS": 0,
+            "references-MIN_NUM_FORMS": 0,
+            "references-MAX_NUM_FORMS": 1000,
+            "references-0-id": "",
+            "references-0-original_text": self.original_text.id,
+            "references-0-editor": "Numa",
+            "references-0-reference_position": "3.2.1",
+        }
+        formset = ReferenceFormset(data=data, instance=self.original_text)
+        if formset.is_valid():
+            formset.save()
+
+        # There should now be three references
+        self.assertEqual(self.original_text.references.count(), 3)
+
+    def test_reference_formset_update(self):
+        new_ref_pos = "7.8.9"
+        data = {
+            "references-TOTAL_FORMS": 1,
+            "references-INITIAL_FORMS": 1,  # Must be >0 if updating
+            "references-MIN_NUM_FORMS": 0,
+            "references-MAX_NUM_FORMS": 1000,
+            "references-0-id": self.reference1.id,
+            "references-0-original_text": self.original_text.id,
+            "references-0-editor": self.reference1.editor,
+            "references-0-reference_position": new_ref_pos,
+        }
+        formset = ReferenceFormset(data=data, instance=self.original_text)
+        self.assertEqual(formset.is_valid(), True)
+        if formset.is_valid():
+            formset.save()
+        self.reference1.refresh_from_db()
+        self.assertEqual(self.reference1.reference_position, new_ref_pos)

--- a/src/rard/research/tests/views/test_original_text.py
+++ b/src/rard/research/tests/views/test_original_text.py
@@ -53,11 +53,18 @@ class TestOriginalTextCreateViews(TestCase):
         # data for both original text and fragment
         data = {
             "content": "content",
-            "reference": "Page 1",
             "reference_order": "1",
             "citing_work": self.citing_work.pk,
             "citing_author": self.citing_work.author.pk,
             "create_object": True,
+            "references-TOTAL_FORMS": 1,
+            "references-INITIAL_FORMS": 0,
+            "references-MIN_NUM_FORMS": 0,
+            "references-MAX_NUM_FORMS": 1000,
+            "references-0-id": "",
+            "references-0-original_text": "",
+            "references-0-editor": "geoff",
+            "references-0-reference_position": "1.2.3",
         }
         # assert no original texts initially
         self.assertEqual(0, OriginalText.objects.count())

--- a/src/rard/research/views/original_text.py
+++ b/src/rard/research/views/original_text.py
@@ -33,6 +33,11 @@ class OriginalTextCreateViewBase(PermissionRequiredMixin, OriginalTextCitingWork
     model = OriginalText
     form_class = OriginalTextForm
 
+    def get_forms(self):
+        forms = super().get_forms()
+        forms["references"] = ReferenceFormset(data=self.request.POST or None)
+        return forms
+
     def dispatch(self, request, *args, **kwargs):
         # need to ensure we have the lock object view attribute
         # initialised in dispatch
@@ -69,6 +74,10 @@ class OriginalTextCreateViewBase(PermissionRequiredMixin, OriginalTextCitingWork
             self.original_text.citing_work = forms["new_citing_work"].save()
 
         self.original_text.save()
+
+        references = forms["references"]
+        references.instance = self.original_text
+        references.save()
 
         return super().forms_valid(forms)
 

--- a/src/rard/templates/research/originaltext_form.html
+++ b/src/rard/templates/research/originaltext_form.html
@@ -26,7 +26,7 @@
         <input type='hidden' name='citing_work' value='{{ citing_work.pk }}' />
 
         {% if citing_author and citing_work %}
-
+            {% include 'research/partials/reference_form.html' %}
             {% bootstrap_field forms.original_text.reference_order %}
 
 

--- a/src/rard/templates/research/originaltext_form.html
+++ b/src/rard/templates/research/originaltext_form.html
@@ -27,7 +27,6 @@
 
         {% if citing_author and citing_work %}
 
-            {% bootstrap_field forms.original_text.reference %}
             {% bootstrap_field forms.original_text.reference_order %}
 
 


### PR DESCRIPTION
Fix for #354.

* Removed mention of original_text.reference field from originaltext_form.html
* Added reference formset to create_form context
* Include reference_form.html in originaltext_form.html
* Fix original_text tests
* Added reference formset tests