### PR TITLE
Add tooltip to show @mention shortcodes

### DIFF
--- a/src/rard/templates/research/partials/rich_text_editor.html
+++ b/src/rard/templates/research/partials/rich_text_editor.html
@@ -5,13 +5,30 @@
     <div class='col h-fill' style='min-height: {% if min_height %}{{ min_height }}{% else %}400{% endif %}px; padding-bottom: {% if padding_bottom != None %}{{ padding_bottom }}{% else %}60{% endif %}px;'>
         <div id='{{ field.auto_id }}_editor' {% if object_class %}data-class='{{ object_class }}'{% endif %} {% if object_id %}data-object='{{ object_id }}'{% endif %} class='rich-editor {% if enable_mentions %}enable-mentions{% endif %} {% if enable_apparatus_criticus %}enable-apparatus-criticus{% endif %}' spellcheck="false"  id='{{ field.auto_id }}_rich_editor_content' data-for='{{ field.auto_id }}'>
         </div>
-        <div class='text-muted'>{% if enable_mentions %}<small>@mentions are enabled.</small>{% endif %}
-        {% if enable_apparatus_criticus %}
-            <small>Type # for apparatus criticus items.</small>
-            {% if object_class %}
-            {# we are editing a parent object's commentary #}
-            <small>Enter a, b, c for the index of the original text where if than one exists for this object</small>
-            {% endif %}
-        {% endif %}</div>
+        <div class='text-muted'>
+          {% if enable_mentions %}
+          <small
+            data-toggle="tooltip"
+            data-html="true"
+            title="
+              Content type codes: </br>
+              @aq - Antiquarian</br>
+              @wk - Work</br>
+              @bi - Bibliography Item</br>
+              @tp - Topic</br>
+              @fr - Fragment</br>
+              @tt - Testimonium</br>
+              @af - Anonymous Fragment</br>
+              @uf - Unlinked Fragment"
+            >@mentions are enabled <i class="bi bi-info-circle"></i></small>
+          {% endif %}
+          {% if enable_apparatus_criticus %}
+              <small>Type # for apparatus criticus items.</small>
+              {% if object_class %}
+              {# we are editing a parent object's commentary #}
+              <small>Enter a, b, c for the index of the original text where if than one exists for this object</small>
+              {% endif %}
+          {% endif %}
+        </div>
     </div>
 </div>


### PR DESCRIPTION
Adds a tooltip and information icon to the "@mentions are enabled" text for reminding users how to search for different content types.