### PR TITLE
Fix reference_position field not being long enough

### DIFF
--- a/src/rard/research/migrations/0060_add_reference_model.py
+++ b/src/rard/research/migrations/0060_add_reference_model.py
@@ -40,7 +40,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("editor", models.CharField(blank=True, max_length=128)),
-                ("reference_position", models.CharField(max_length=50)),
+                ("reference_position", models.CharField(max_length=128)),
                 (
                     "original_text",
                     models.ForeignKey(

--- a/src/rard/research/models/reference.py
+++ b/src/rard/research/models/reference.py
@@ -7,7 +7,7 @@ class Reference(models.Model):
 
     # The value to be used to refer to the position in the text
     # In some cases it will be a dot-separated list of numbers eg. 2.6-8
-    reference_position = models.CharField(blank=False, max_length=50)
+    reference_position = models.CharField(blank=False, max_length=128)
 
     original_text = models.ForeignKey(
         "OriginalText",


### PR DESCRIPTION
Update to production failed because new reference_position field has 50 char limit, but original reference field on original text had 128 char limit.