### PR TITLE
Fix bibliography inline form textarea height to prevent overlap

### DIFF
--- a/src/rard/research/forms.py
+++ b/src/rard/research/forms.py
@@ -677,7 +677,8 @@ class TestimoniumAntiquariansForm(HistoricalFormBase):
 
 
 class BibliographyItemInlineForm(HistoricalFormBase):
-    title = forms.CharField(widget=forms.Textarea(attrs={'rows':1}))
+    title = forms.CharField(widget=forms.Textarea(attrs={"rows": 1}))
+
     class Meta:
         model = BibliographyItem
         fields = (

--- a/src/rard/research/forms.py
+++ b/src/rard/research/forms.py
@@ -677,6 +677,7 @@ class TestimoniumAntiquariansForm(HistoricalFormBase):
 
 
 class BibliographyItemInlineForm(HistoricalFormBase):
+    title = forms.CharField(widget=forms.Textarea(attrs={'rows':1}))
     class Meta:
         model = BibliographyItem
         fields = (

--- a/src/rard/research/models/work.py
+++ b/src/rard/research/models/work.py
@@ -302,6 +302,7 @@ def create_unknown_book(sender, instance, **kwargs):
         unknown_book.save()
         # call function to make sure unknown book contents are collated
 
+
 @disable_for_loaddata
 def handle_reordered_books(sender, instance, **kwargs):
     # reindex links for antiquarian

--- a/src/rard/static/css/project.css
+++ b/src/rard/static/css/project.css
@@ -418,6 +418,13 @@ table.ql-table {
 
 #bib-inline-form {
   opacity: 1;
-  max-height: 50vh;
+  max-height: 60vh;
   transition: max-height 1s ease-out, opacity 1s ease-out;
+}
+
+#bib-inline-form textarea {
+  overflow: auto;
+  max-height: 6rem;
+  min-height: 3rem;
+  resize: vertical;
 }

--- a/src/rard/templates/research/inline_forms/bibliographyitem_form.html
+++ b/src/rard/templates/research/inline_forms/bibliographyitem_form.html
@@ -13,8 +13,7 @@
     {% bootstrap_field form.year %}
     </div>
   </div>
-    {% bootstrap_field form.title field_class='d-none' %}
-    {% include 'research/partials/rich_text_editor.html' with field=form.title min_height=100 %}
+  {% bootstrap_field form.title %}
     {% comment %} {% bootstrap_field form.antiquarians %}
     {% bootstrap_field form.citing_authors %} {% endcomment %}
   <div>


### PR DESCRIPTION
Fix for the create bibliography item inline form which was overlapping the table below it.
* Switched title field to use regular textarea widget rather than rich text editor
* Set rows to 1, resizable to ~3 rows
* Made max form height slightly larger