### PR TITLE
Fix/414

### DIFF
--- a/src/rard/research/forms.py
+++ b/src/rard/research/forms.py
@@ -928,20 +928,12 @@ class AppositumFragmentLinkForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-        self.fields["linked_to"].initial = Fragment.objects.all()
-
-    def get_fragment_queryset(self):
-        queryset = Fragment.objects.all()
-
-        # Example filter based on some condition
-        antiquarian_id = self.cleaned_data.get("antiquarian")
-        if antiquarian_id:
-            queryset = queryset.filter(antiquarian_id=antiquarian_id)
-
-        # Add more filters as needed (e.g., Work, Book)
-
-        return queryset
+        self.fields["linked_to"].widget = forms.Select(
+            attrs={
+                "id": "search-results",
+            },
+            choices=[("", "Results will appear here")],
+        )
 
 
 class CitingWorkCreateForm(forms.ModelForm):

--- a/src/rard/research/forms.py
+++ b/src/rard/research/forms.py
@@ -931,6 +931,18 @@ class AppositumFragmentLinkForm(forms.ModelForm):
 
         self.fields["linked_to"].initial = Fragment.objects.all()
 
+    def get_fragment_queryset(self):
+        queryset = Fragment.objects.all()
+
+        # Example filter based on some condition
+        antiquarian_id = self.cleaned_data.get("antiquarian")
+        if antiquarian_id:
+            queryset = queryset.filter(antiquarian_id=antiquarian_id)
+
+        # Add more filters as needed (e.g., Work, Book)
+
+        return queryset
+
 
 class CitingWorkCreateForm(forms.ModelForm):
     class Meta:

--- a/src/rard/research/models/fragment.py
+++ b/src/rard/research/models/fragment.py
@@ -141,6 +141,7 @@ class Fragment(HistoryModelMixin, HistoricalBaseModel, DatedModel):
     def save(self, *args, **kwargs):
         if self.commentary:
             self.plain_commentary = make_plain_text(self.commentary.content)
+
         super().save(*args, **kwargs)
 
     def __str__(self):

--- a/src/rard/research/urls.py
+++ b/src/rard/research/urls.py
@@ -297,6 +297,11 @@ urlpatterns = [
                         views.FragmentOriginalTextCreateView.as_view(),
                         name="create_original_text",
                     ),
+                    path(
+                        "fetch-fragments",
+                        views.fetch_fragments,
+                        name="fetch_fragments",
+                    ),
                     # include common urls here
                     path("", include(common_patterns)),
                 ],

--- a/src/rard/research/views/__init__.py
+++ b/src/rard/research/views/__init__.py
@@ -78,6 +78,7 @@ from .fragment import (
     RemoveFragmentLinkView,
     UnlinkedFragmentConvertToAnonymousView,
     UnlinkedFragmentListView,
+    fetch_fragments,
 )
 from .history import HistoryListView
 from .home import HomeView, render_editor_modal_template
@@ -205,6 +206,7 @@ __all__ = [
     "FragmentUpdateView",
     "FragmentUpdateWorkLinkView",
     "FragmentUpdateAntiquariansView",
+    "fetch_fragments",
     "HistoryListView",
     "HomeView",
     "MentionSearchView",

--- a/src/rard/research/views/fragment.py
+++ b/src/rard/research/views/fragment.py
@@ -41,6 +41,7 @@ from rard.research.models import (
 )
 from rard.research.models.base import AppositumFragmentLink, FragmentLink
 from rard.research.models.fragment import AnonymousTopicLink
+from rard.research.views.mention import MentionSearchView
 from rard.research.views.mixins import (
     CanLockMixin,
     CheckLockMixin,
@@ -988,3 +989,17 @@ class MoveAnonymousTopicLinkView(LoginRequiredMixin, View):
                 raise Http404
 
         raise Http404
+
+
+def fetch_fragments(request):
+    query = request.GET.get("search-fragments")
+    if "unlinked" in query:
+        fragments = MentionSearchView.unlinked_fragment_search(query)
+    else:
+        fragments = MentionSearchView.fragment_search(query)
+
+    return render(
+        request,
+        "research/partials/htmx_fragment_results.html",
+        {"fragments": fragments},
+    )

--- a/src/rard/research/views/fragment.py
+++ b/src/rard/research/views/fragment.py
@@ -992,11 +992,17 @@ class MoveAnonymousTopicLinkView(LoginRequiredMixin, View):
 
 
 def fetch_fragments(request):
+    # Mention search methods expect a list of search terms so split on space
     query = request.GET.get("search-fragments")
-    if "unlinked" in query:
-        fragments = MentionSearchView.unlinked_fragment_search(query)
+    if query:
+        search_terms = query.split(" ")
+        if "unlinked" in search_terms:
+            fragments = MentionSearchView.unlinked_fragment_search(search_terms)
+        else:
+            fragments = MentionSearchView.fragment_search(search_terms)
     else:
-        fragments = MentionSearchView.fragment_search(query)
+        # empty query => empty fragment queryset
+        fragments = Fragment.objects.none()
 
     return render(
         request,

--- a/src/rard/templates/research/add_appositum_fragment_link.html
+++ b/src/rard/templates/research/add_appositum_fragment_link.html
@@ -13,7 +13,8 @@
     <form novalidate enctype="multipart/form-data" autocomplete='off' action='{{ request.path }}' class="form" method='POST'>
         {% csrf_token %}
         <input type="text" id="search-fragments" name="search-fragments" placeholder="Start typing to search for fragments..." hx-get="{% url 'fragment:fetch_fragments' %}" hx-trigger="keyup delay:500ms changed" hx-swap="innerHTML" hx-target="#search-results" class="form-control">
-
+        <small class="text-muted">You may search by antiquarian name and include a number referring to the fragment number, eg. "publius 12". For unlinked, search "unlinked" </small>
+        <br></br>
         {% bootstrap_field form.linked_to %}
 
 

--- a/src/rard/templates/research/add_appositum_fragment_link.html
+++ b/src/rard/templates/research/add_appositum_fragment_link.html
@@ -12,7 +12,10 @@
 
     <form novalidate enctype="multipart/form-data" autocomplete='off' action='{{ request.path }}' class="form" method='POST'>
         {% csrf_token %}
+        <input type="text" id="search-fragments" name="search-fragments" placeholder="Start typing to search for fragments..." hx-get="{% url 'fragment:fetch_fragments' %}" hx-trigger="keyup delay:500ms changed" hx-swap="innerHTML" hx-target="#search-results" class="form-control">
+
         {% bootstrap_field form.linked_to %}
+
 
         <button type="submit" class="btn btn-primary">
             {% trans 'Create' %}
@@ -21,5 +24,4 @@
             {% trans 'Create and add another' %}
         </button>
     </form>
-    {{ form.media.js }}
 {% endblock %}

--- a/src/rard/templates/research/add_appositum_fragment_link.html
+++ b/src/rard/templates/research/add_appositum_fragment_link.html
@@ -5,6 +5,7 @@
     {% blocktrans with name=form.instance.linked_field %}
         Add appositum link to fragment
     {% endblocktrans %}
+    {{ form.media.css }}
 {% endblock %}
 
 {% block inner %}
@@ -20,5 +21,5 @@
             {% trans 'Create and add another' %}
         </button>
     </form>
-
+    {{ form.media.js }}
 {% endblock %}

--- a/src/rard/templates/research/partials/htmx_fragment_results.html
+++ b/src/rard/templates/research/partials/htmx_fragment_results.html
@@ -1,3 +1,7 @@
-{% for frag in fragments %}
+{% if fragments %}
+  {% for frag in fragments %}
         <option value="{{frag.pk}}">{{frag}}</option>
-{% endfor %}
+  {% endfor %}
+{% else %}
+  <option value="" selected="">Results will appear here</option>
+{% endif %}

--- a/src/rard/templates/research/partials/htmx_fragment_results.html
+++ b/src/rard/templates/research/partials/htmx_fragment_results.html
@@ -1,0 +1,3 @@
+{% for frag in fragments %}
+        <option value="{{frag.pk}}">{{frag}}</option>
+{% endfor %}


### PR DESCRIPTION
Closes #414 
----
Have changed the appositum-fragment linking form to search and then populate a dropdown, whose value gets submitted as previously. The search is triggered on keyup with a delay of 500ms. It utilises the preexisting functions within the `MentionSearchView` to search for the normal or unlinked fragments.