### PR TITLE
move links between works proposed changes

### DIFF
--- a/src/rard/research/forms.py
+++ b/src/rard/research/forms.py
@@ -789,14 +789,16 @@ class BaseLinkWorkForm(forms.ModelForm):
         }
 
     def __init__(self, *args, **kwargs):
+        # First remove the form kwargs added by GetWorkLinkRequestDataMixin
         update = kwargs.pop("update")
         antiquarian = kwargs.pop("antiquarian")
         work = kwargs.pop("work")
-        book = kwargs.get("book")
+        book = kwargs.pop("book")
         definite_antiquarian = kwargs.pop("definite_antiquarian")
         definite_work = kwargs.pop("definite_work")
-
         super().__init__(*args, **kwargs)
+
+        # Setup fields
         self.fields["book"].required = False
         self.fields["work"].required = False
         self.fields["definite_antiquarian"] = forms.BooleanField(required=False)
@@ -804,36 +806,45 @@ class BaseLinkWorkForm(forms.ModelForm):
         self.fields["definite_book"] = forms.BooleanField(required=False)
 
         if update:
-            antiquarian = kwargs["initial"]["antiquarian"]
-            work = kwargs["initial"]["work"]
-            self.fields["book"].empty_label = None
+            # We don't need empty labels on select widgets if it's an update
+            self.fields["antiquarian"].empty_label = None
             self.fields["work"].empty_label = None
+            self.fields["book"].empty_label = None
+
             if "data" in kwargs:
-                # this is where the new values are
-                work = Work.objects.get(pk=kwargs["data"]["work"])
-                if kwargs["data"]["book"]:
-                    book = Book.objects.get(pk=kwargs["data"]["book"])
+                # Get Work and Book from post data
+                if work_id := kwargs["data"]["work"]:
+                    work = Work.objects.get(pk=work_id)
+                if book_id := kwargs["data"]["book"]:
+                    book = Book.objects.get(pk=book_id)
+                antiquarian = Antiquarian.objects.get(pk=kwargs["data"]["antiquarian"])
+            else:
+                # Get everything from initial
+                antiquarian = kwargs["initial"]["antiquarian"]
+                definite_antiquarian = kwargs["initial"]["definite_antiquarian"]
+                work = kwargs["initial"]["work"]
+                definite_work = kwargs["initial"]["definite_work"]
+                book = kwargs["initial"]["book"]
 
         if antiquarian:
             self.fields["antiquarian"].initial = antiquarian
             self.fields["work"].queryset = antiquarian.works.all()
-            if update is not True:
-                self.fields["definite_antiquarian"].initial = definite_antiquarian
+            self.fields["definite_antiquarian"].initial = definite_antiquarian
         else:
             self.fields["work"].queryset = Work.objects.none()
-            if update is not True:
-                self.fields["work"].disabled = True
-                self.fields["definite_work"].widget.attrs["disabled"] = True
+            self.fields["work"].disabled = True
+            self.fields["definite_work"].widget.attrs["disabled"] = True
+            self.fields["book"].disabled = True
+            self.fields["definite_book"].widget.attrs["disabled"] = True
 
         if work:
+            self.fields["work"].initial = work
+            self.fields["book"].queryset = work.book_set.all()
+            self.fields["definite_work"].initial = definite_work
             if work.unknown:
+                # Neither work or book can be definite
                 self.fields["definite_work"].widget.attrs["disabled"] = True
-            if antiquarian:
-                self.fields["work"].initial = work
-                self.fields["definite_work"].initial = definite_work
-            else:
-                self.fields["work"].initial = None
-
+                self.fields["definite_book"].widget.attrs["disabled"] = True
             self.fields["work"].widget.attrs.update(
                 {
                     "hx-get": reverse("work:fetch_books"),
@@ -842,16 +853,12 @@ class BaseLinkWorkForm(forms.ModelForm):
                     "hx-target": "select#id_book",
                 }
             )
-            self.fields["book"].queryset = work.book_set.all()
         else:
             self.fields["book"].queryset = Book.objects.none()
-            if update is not True:
-                self.fields["book"].disabled = True
-                self.fields["definite_book"].widget.attrs["disabled"] = True
+            self.fields["book"].disabled = True
+            self.fields["definite_book"].widget.attrs["disabled"] = True
 
         if book:
-            if self.fields["definite_book"] is True:
-                self.fields["book"].disabled = True
             if book.unknown:
                 self.fields["definite_book"].widget.attrs["disabled"] = True
 

--- a/src/rard/research/forms.py
+++ b/src/rard/research/forms.py
@@ -806,6 +806,8 @@ class BaseLinkWorkForm(forms.ModelForm):
         if update:
             antiquarian = kwargs["initial"]["antiquarian"]
             work = kwargs["initial"]["work"]
+            self.fields["book"].empty_label = None
+            self.fields["work"].empty_label = None
             if "data" in kwargs:
                 # this is where the new values are
                 work = Work.objects.get(pk=kwargs["data"]["work"])

--- a/src/rard/research/models/antiquarian.py
+++ b/src/rard/research/models/antiquarian.py
@@ -390,7 +390,7 @@ class Antiquarian(
 @disable_for_loaddata
 def collate_unknown(instance):
     """This makes sure there's only one unknown work per antiquarian and combines contents if otherwise"""
-    unknown_works = instance.works.filter(unknown=True)
+    unknown_works = instance.works.filter(unknown=True).order_by("pk")
 
     if unknown_works.count() > 1:
         designated_unknown = unknown_works.first()

--- a/src/rard/research/tests/forms/test_fragment.py
+++ b/src/rard/research/tests/forms/test_fragment.py
@@ -36,6 +36,7 @@ class TestFragmentLinkWorkForm(TestCase):
         form = FragmentLinkWorkForm(
             antiquarian=None,
             work=None,
+            book=None,
             definite_antiquarian=False,
             definite_work=False,
             update=False,
@@ -54,6 +55,7 @@ class TestFragmentLinkWorkForm(TestCase):
         form = FragmentLinkWorkForm(
             antiquarian=antiquarian,
             work=None,
+            book=None,
             definite_antiquarian=False,
             definite_work=False,
             update=False,
@@ -79,6 +81,7 @@ class TestFragmentLinkWorkForm(TestCase):
         form = FragmentLinkWorkForm(
             antiquarian=antiquarian,
             work=work,
+            book=None,
             definite_antiquarian=False,
             definite_work=False,
             update=False,

--- a/src/rard/research/tests/models/test_antiquarian.py
+++ b/src/rard/research/tests/models/test_antiquarian.py
@@ -226,14 +226,14 @@ class TestAntiquarian(TestCase):
     def test_collate_unknown(self):
         data = {"name": "John Smith", "re_code": "smitre001"}
         a = Antiquarian.objects.create(**data)
-        original_unknown = a.unknown_work
+        original_unknown_pk = a.unknown_work.pk
         additional_unknown = Work.objects.create(unknown=True, name="Unknown Work")
         additional_unknown.antiquarian_set.add(a)
         additional_unknown.save()
         self.assertEqual(a.works.filter(unknown=True).count(), 2)
         collate_unknown(a)
         self.assertEqual(a.works.filter(unknown=True).count(), 1)
-        self.assertEqual(original_unknown.pk, a.unknown_work.pk)
+        self.assertEqual(original_unknown_pk, a.unknown_work.pk)
 
 
 class TestWorkLink(TestCase):

--- a/src/rard/research/views/mixins.py
+++ b/src/rard/research/views/mixins.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.views.generic import DetailView
 
-from rard.research.models import Antiquarian, Work
+from rard.research.models import Antiquarian, Book, Work
 
 
 class DateOrderMixin:
@@ -134,6 +134,20 @@ class GetWorkLinkRequestDataMixin:
         else:
             return False
 
+    def get_book(self, *args, **kwargs):
+        # look for book in the GET or POST parameters
+        self.book = None
+        if self.request.method == "GET":
+            book_pk = self.request.GET.get("book", None)
+        elif self.request.method == "POST":
+            book_pk = self.request.POST.get("book", None)
+        if book_pk:
+            try:
+                self.book = Book.objects.get(pk=book_pk)
+            except Book.DoesNotExist:
+                raise Http404
+        return self.book
+
     def get_definite_book(self, *args, **kwargs):
         # look for definite_book in the GET or POST parameters
         if self.request.method == "GET":
@@ -147,6 +161,7 @@ class GetWorkLinkRequestDataMixin:
         values = super().get_form_kwargs()
         values["antiquarian"] = self.get_antiquarian()
         values["work"] = self.get_work()
+        values["book"] = self.get_book()
         values["definite_antiquarian"] = self.get_definite_antiquarian()
         values["definite_work"] = self.get_definite_work()
         values["update"] = self.is_update

--- a/src/rard/static/js/disableDefiniteToggles.js
+++ b/src/rard/static/js/disableDefiniteToggles.js
@@ -20,12 +20,16 @@ workSelectElems.forEach((select) => {
     var target = e.target;
     var value = target.selectedOptions[0].innerText;
     var parentElem = target.closest(".work-details");
-    var definiteBookToggle = parentElem.querySelector("#id_definite_work");
+    var definiteWorkToggle = parentElem.querySelector("#id_definite_work");
+    var parentForm = target.closest("form");
+    var definiteBookToggle = parentForm.querySelector("#id_definite_book");
 
     if (value.toString().toLowerCase().includes("unknown")) {
+      definiteWorkToggle.disabled = true;
+      definiteWorkToggle.checked = false;
       definiteBookToggle.disabled = true;
       definiteBookToggle.checked = false;
-    } else definiteBookToggle.disabled = false;
+    } else definiteWorkToggle.disabled = false;
   };
 });
 

--- a/src/rard/templates/research/partials/render_htmx_book_field.html
+++ b/src/rard/templates/research/partials/render_htmx_book_field.html
@@ -1,6 +1,5 @@
 {# Used when rendering books fetched for inline fragment update #}
 
-<option value="">---------</option>
 {% for book in books %}
         {% if book.unknown %}
         <option value="{{book.pk}}" selected>{{book}}</option>


### PR DESCRIPTION
I was looking for a way to remove the none-option from the select boxes and went down a bit of a rabbit hole.
Anyway, I hope it's useful.

* Removes none-option from Work and Book select boxes when using form to update existing links
* Refactor the form's __init__ method to hopefully make it a bit more readable
* Update disable checkbox js to disable definite book as well as def work checkboxes when Unknown Work selected
