### PR TITLE
Fixing paste behaviour into text editor

### DIFF
--- a/src/rard/static/js/project.js
+++ b/src/rard/static/js/project.js
@@ -241,37 +241,7 @@ async function getApparatusCriticusLines(searchTerm, object_id, object_class) {
   });
   return matches;
 }
-function textnode(node, delta) {
-  if (node.data) {
-    // console.log(
-    //   "textnode: node:",
-    //   node,
-    //   "node data",
-    //   node.nodeType,
-    //   node.nodeValue,
-    //   "delta",
-    //   delta
-    // );
-    const textContent = node.data; // Get text content of the text node
-    const newDelta = new Delta().insert(textContent); // Create a new Delta with the text content
-    return delta.compose(newDelta);
-  }
-  return delta;
-}
-function elemnode(node, delta) {
-  if (node.data) {
-    console.log(
-      "elemnode: node:"
-      //   node,
-      //   "node data",
-      //   node.data,
-      //   "delta",
-      //   delta
-    );
-    return delta;
-  }
-  return delta;
-}
+
 function initRichTextEditor($item) {
   let config = {
     theme: "snow",
@@ -395,12 +365,6 @@ function initRichTextEditor($item) {
       },
       footnote: true,
       table: true,
-      clipboard: {
-        matchers: [
-          [Node.ELEMENT_NODE, elemnode],
-          [Node.TEXT_NODE, textnode],
-        ],
-      },
     },
   };
 
@@ -457,8 +421,8 @@ function initRichTextEditor($item) {
   $item.find(".ql-editor").html(html);
   $for.hide();
 
+  // This removes the weird br header element that gets pasted
   var editor = $item.find(".ql-editor").get(0);
-
   editor.addEventListener("paste", function (event) {
     var h4brElem = this.querySelector("h4 br");
     h4brElem.remove();
@@ -479,8 +443,6 @@ function initRichTextEditor($item) {
   $("body").on("htmx:configRequest", function (e) {
     let html = $item.find(".ql-editor").html();
     e.detail.parameters[model_field] = html;
-
-    console.log(html);
   });
 }
 

--- a/src/rard/static/js/project.js
+++ b/src/rard/static/js/project.js
@@ -241,7 +241,37 @@ async function getApparatusCriticusLines(searchTerm, object_id, object_class) {
   });
   return matches;
 }
-
+function textnode(node, delta) {
+  if (node.data) {
+    // console.log(
+    //   "textnode: node:",
+    //   node,
+    //   "node data",
+    //   node.nodeType,
+    //   node.nodeValue,
+    //   "delta",
+    //   delta
+    // );
+    const textContent = node.data; // Get text content of the text node
+    const newDelta = new Delta().insert(textContent); // Create a new Delta with the text content
+    return delta.compose(newDelta);
+  }
+  return delta;
+}
+function elemnode(node, delta) {
+  if (node.data) {
+    console.log(
+      "elemnode: node:"
+      //   node,
+      //   "node data",
+      //   node.data,
+      //   "delta",
+      //   delta
+    );
+    return delta;
+  }
+  return delta;
+}
 function initRichTextEditor($item) {
   let config = {
     theme: "snow",
@@ -365,6 +395,12 @@ function initRichTextEditor($item) {
       },
       footnote: true,
       table: true,
+      clipboard: {
+        matchers: [
+          [Node.ELEMENT_NODE, elemnode],
+          [Node.TEXT_NODE, textnode],
+        ],
+      },
     },
   };
 
@@ -421,6 +457,13 @@ function initRichTextEditor($item) {
   $item.find(".ql-editor").html(html);
   $for.hide();
 
+  var editor = $item.find(".ql-editor").get(0);
+
+  editor.addEventListener("paste", function (event) {
+    var h4brElem = this.querySelector("h4 br");
+    h4brElem.remove();
+  });
+
   // translates custom table dropdown in toolbar
   var tablePickerItems = Array.prototype.slice.call(
     document.querySelectorAll(".ql-edit_table .ql-picker-item")
@@ -436,6 +479,8 @@ function initRichTextEditor($item) {
   $("body").on("htmx:configRequest", function (e) {
     let html = $item.find(".ql-editor").html();
     e.detail.parameters[model_field] = html;
+
+    console.log(html);
   });
 }
 

--- a/src/rard/static/js/quill-footnotes.js
+++ b/src/rard/static/js/quill-footnotes.js
@@ -72,11 +72,13 @@ class Footnote extends Module {
   }
 
   async insertFootnote() {
+    console.log("inserting footnote");
     var footnoteNumber = this.countFootnotes();
     const range = this.quill.getSelection();
     const index = range ? range.index : this.quill.getLength();
     if (!this.editorArea.querySelector(`.footnote-area`)) {
       // create the footnote area inside the ql-editor if it doesn't exist
+      console.log("adding footnote area");
       this.quill.insertEmbed(this.quill.getLength(), "footnote-area", "");
     }
     this.footnoteArea = this.editorArea.querySelector(`.footnote-area`);


### PR DESCRIPTION
closes #423 
---
The text editor was interpreting something (probably a carriage return) as a `<br>` which then got turned into a `<h4><br></h4>` and trigger the footnote area to be made with no content aside from the `<hr>`. This proved difficult to remove unless you knew where the element was but regardless, this behaviour wasn't expected. This can be bypassed on some browsers with the "force paste" option
The solution listens for a paste event and on paste removes the h4 br element inserted. This seems to work across browsers in my testing and doesn't seem to interfere with preexisting footnotes.