### PR TITLE
Feature/duplicate fragment

### DIFF
--- a/src/rard/research/tests/views/test_fragment.py
+++ b/src/rard/research/tests/views/test_fragment.py
@@ -175,7 +175,9 @@ class TestFragmentSuccessUrls(TestCase):
         # Simulate the behavior of the duplicate_fragment view
         request = RequestFactory().get("/")
         request.user = UserFactory.create()
-        response = duplicate_fragment(request, original_fragment.pk)
+        response = duplicate_fragment(
+            request, original_fragment.pk, model_name="fragment"
+        )
         duplicate_pk = response.url.split("/")[-2]
 
         expected_url = reverse(

--- a/src/rard/research/tests/views/test_fragment.py
+++ b/src/rard/research/tests/views/test_fragment.py
@@ -180,9 +180,7 @@ class TestFragmentSuccessUrls(TestCase):
         )
         duplicate_pk = response.url.split("/")[-2]
 
-        expected_url = reverse(
-            "fragment:detail", kwargs={"pk": duplicate_pk, "model_name": "fragment"}
-        )
+        expected_url = reverse("fragment:detail", kwargs={"pk": duplicate_pk})
 
         self.assertEqual(response.url, expected_url)
         self.assertEqual(response.status_code, 302)

--- a/src/rard/research/tests/views/test_fragment.py
+++ b/src/rard/research/tests/views/test_fragment.py
@@ -12,9 +12,12 @@ from rard.research.models import (
     CitingWork,
     Fragment,
     OriginalText,
+    Reference,
     Topic,
 )
 from rard.research.models.base import AppositumFragmentLink, FragmentLink
+from rard.research.models.linkable import ApparatusCriticusItem
+from rard.research.models.original_text import Concordance
 from rard.research.models.text_object_field import TextObjectField
 from rard.research.views import (
     AnonymousFragmentConvertToFragmentView,
@@ -27,6 +30,7 @@ from rard.research.views import (
     MoveAnonymousTopicLinkView,
     UnlinkedFragmentConvertToAnonymousView,
 )
+from rard.research.views.fragment import duplicate_fragment
 from rard.users.tests.factories import UserFactory
 from rard.utils.convertors import (
     FragmentIsNotConvertible,
@@ -163,6 +167,20 @@ class TestFragmentSuccessUrls(TestCase):
             view.get_success_url(),
             reverse("fragment:detail", kwargs={"pk": view.object.pk}),
         )
+
+    def test_duplication_success_url(self):
+        original_fragment = Fragment.objects.create(name="some name")
+
+        # Simulate the behavior of the duplicate_fragment view
+        request = RequestFactory().get("/")
+        request.user = UserFactory.create()
+        response = duplicate_fragment(request, original_fragment.pk)
+        duplicate_pk = response.url.split("/")[-2]
+
+        expected_url = reverse("fragment:detail", kwargs={"pk": duplicate_pk})
+
+        self.assertEqual(response.url, expected_url)
+        self.assertEqual(response.status_code, 302)
 
 
 class TestFragmentDeleteView(TestCase):
@@ -492,3 +510,48 @@ class TestOrderAnonymousFragmentListView(TestCase):
             response.context_data["object_list"],
             [self.aftl1, self.aftl3, self.aftl2, self.aftl3],
         )
+
+
+class TestFragmentDuplicationView(TestCase):
+    def setUp(self):
+        self.cw = CitingWork.objects.create(title="citing work title")
+        self.ot = OriginalText.objects.create(
+            content="Original Text test",
+            apparatus_criticus_blank=False,
+            apparatus_criticus="here be the app crit",
+            object_id=111,
+            citing_work=self.cw,
+            content_type_id=12,
+            reference_order="reference order",
+        )
+        self.c = Concordance.objects.create(
+            original_text=self.ot, source="tester", identifier="123"
+        )
+        self.ac = ApparatusCriticusItem.objects.create(
+            parent=self.ot, content="critical test", object_id=23
+        )
+        self.r = Reference.objects.create(editor="test", original_text=self.ot)
+        self.t = Topic.objects.create(name="topic1")
+        self.f = Fragment.objects.create(name="test fragment")
+        self.f.topics.add(self.t)
+        self.f.original_texts.add(self.ot)
+
+    def test_duplication(self):
+        url = reverse("fragment:duplicate", kwargs={"pk": self.f.pk})
+        request = RequestFactory().get(url)
+        request.user = UserFactory.create()
+        response = duplicate_fragment(request, pk=self.f.pk)
+        duplicate_pk = response.url.split("/")[-2]
+        duplicate_frag = Fragment.objects.get(pk=duplicate_pk)
+
+        for field in duplicate_frag._meta.fields:
+            if field.name in [
+                "id",
+                "created",
+                "modified",
+            ]:
+                continue
+            print(field.name)
+            value1 = getattr(duplicate_frag, field.name)
+            value2 = getattr(self.f, field.name)
+            self.assertEqual(value1, value2)

--- a/src/rard/research/tests/views/test_fragment.py
+++ b/src/rard/research/tests/views/test_fragment.py
@@ -14,6 +14,7 @@ from rard.research.models import (
     OriginalText,
     Reference,
     Topic,
+    Translation,
 )
 from rard.research.models.base import AppositumFragmentLink, FragmentLink
 from rard.research.models.linkable import ApparatusCriticusItem
@@ -524,34 +525,62 @@ class TestFragmentDuplicationView(TestCase):
             content_type_id=12,
             reference_order="reference order",
         )
-        self.c = Concordance.objects.create(
+        self.con = Concordance.objects.create(
             original_text=self.ot, source="tester", identifier="123"
         )
-        self.ac = ApparatusCriticusItem.objects.create(
+        self.apc = ApparatusCriticusItem.objects.create(
             parent=self.ot, content="critical test", object_id=23
         )
-        self.r = Reference.objects.create(editor="test", original_text=self.ot)
-        self.t = Topic.objects.create(name="topic1")
-        self.f = Fragment.objects.create(name="test fragment")
-        self.f.topics.add(self.t)
-        self.f.original_texts.add(self.ot)
+        self.tr = Translation.objects.create(
+            translated_text="translation of text", original_text=self.ot
+        )
+        self.ref = Reference.objects.create(editor="test", original_text=self.ot)
+        self.topic = Topic.objects.create(name="topic1")
+        self.frag = Fragment.objects.create(name="test fragment")
+        self.frag.topics.add(self.topic)
+        self.frag.original_texts.add(self.ot)
 
-    def test_duplication(self):
-        url = reverse("fragment:duplicate", kwargs={"pk": self.f.pk})
-        request = RequestFactory().get(url)
-        request.user = UserFactory.create()
-        response = duplicate_fragment(request, pk=self.f.pk)
-        duplicate_pk = response.url.split("/")[-2]
-        duplicate_frag = Fragment.objects.get(pk=duplicate_pk)
-
-        for field in duplicate_frag._meta.fields:
+    def compare_model_objects(self, original, duplicate):
+        for field in original._meta.fields:
             if field.name in [
                 "id",
                 "created",
                 "modified",
+                "commentary",
+                "object_id",
+                "original_text",
             ]:
                 continue
-            print(field.name)
-            value1 = getattr(duplicate_frag, field.name)
-            value2 = getattr(self.f, field.name)
-            self.assertEqual(value1, value2)
+            if field.is_relation and getattr(original, field.name) is not None:
+                # If the field is a relation and is not None, recursively compare the related objects
+                related_original = getattr(original, field.name)
+                related_duplicate = getattr(duplicate, field.name)
+                self.compare_model_objects(related_original, related_duplicate)
+            else:
+                # For regular fields or null relations, compare their values
+                value1 = getattr(original, field.name)
+                value2 = getattr(duplicate, field.name)
+                self.assertEqual(value1, value2)
+
+    def test_duplication(self):
+        url = reverse("fragment:duplicate", kwargs={"pk": self.frag.pk})
+        request = RequestFactory().get(url)
+        request.user = UserFactory.create()
+        response = duplicate_fragment(request, pk=self.frag.pk)
+        duplicate_pk = response.url.split("/")[-2]
+        duplicate_frag = Fragment.objects.get(pk=duplicate_pk)
+        duplicate_ot = duplicate_frag.original_texts.first()
+        duplicate_ref = duplicate_ot.references.first()
+        duplicate_apc = duplicate_ot.apparatus_criticus_items.first()
+        duplicate_con = duplicate_ot.concordances.first()
+        duplicate_tr = Translation.objects.filter(original_text=duplicate_ot).first()
+
+        self.compare_model_objects(self.frag, duplicate_frag)
+        self.assertEqual(
+            list(self.frag.topics.all()), list(duplicate_frag.topics.all())
+        )
+        self.compare_model_objects(self.ot, duplicate_ot)
+        self.compare_model_objects(self.ref, duplicate_ref)
+        self.compare_model_objects(self.apc, duplicate_apc)
+        self.compare_model_objects(self.con, duplicate_con)
+        self.compare_model_objects(self.tr, duplicate_tr)

--- a/src/rard/research/tests/views/test_fragment.py
+++ b/src/rard/research/tests/views/test_fragment.py
@@ -8,18 +8,19 @@ from rard.research.models import (
     AnonymousFragment,
     AnonymousTopicLink,
     Antiquarian,
+    ApparatusCriticusItem,
+    AppositumFragmentLink,
     CitingAuthor,
     CitingWork,
+    Concordance,
     Fragment,
+    FragmentLink,
     OriginalText,
     Reference,
+    TextObjectField,
     Topic,
     Translation,
 )
-from rard.research.models.base import AppositumFragmentLink, FragmentLink
-from rard.research.models.linkable import ApparatusCriticusItem
-from rard.research.models.original_text import Concordance
-from rard.research.models.text_object_field import TextObjectField
 from rard.research.views import (
     AnonymousFragmentConvertToFragmentView,
     AnonymousFragmentListView,
@@ -30,8 +31,8 @@ from rard.research.views import (
     FragmentUpdateView,
     MoveAnonymousTopicLinkView,
     UnlinkedFragmentConvertToAnonymousView,
+    duplicate_fragment,
 )
-from rard.research.views.fragment import duplicate_fragment
 from rard.users.tests.factories import UserFactory
 from rard.utils.convertors import (
     FragmentIsNotConvertible,

--- a/src/rard/research/tests/views/test_fragment.py
+++ b/src/rard/research/tests/views/test_fragment.py
@@ -178,7 +178,9 @@ class TestFragmentSuccessUrls(TestCase):
         response = duplicate_fragment(request, original_fragment.pk)
         duplicate_pk = response.url.split("/")[-2]
 
-        expected_url = reverse("fragment:detail", kwargs={"pk": duplicate_pk})
+        expected_url = reverse(
+            "fragment:detail", kwargs={"pk": duplicate_pk, "model_name": "fragment"}
+        )
 
         self.assertEqual(response.url, expected_url)
         self.assertEqual(response.status_code, 302)

--- a/src/rard/research/urls.py
+++ b/src/rard/research/urls.py
@@ -296,7 +296,12 @@ urlpatterns = [
                         views.UnlinkedFragmentConvertToAnonymousView.as_view(),
                         name="convert_to_anonymous",
                     ),
-                    path("<pk>/duplicate", views.duplicate_fragment, {"model_name":"fragment"}, name="duplicate"),
+                    path(
+                        "<pk>/duplicate",
+                        views.duplicate_fragment,
+                        {"model_name": "fragment"},
+                        name="duplicate",
+                    ),
                     path("<pk>/", views.FragmentDetailView.as_view(), name="detail"),
                     path(
                         "<pk>/create-original-text/",
@@ -369,7 +374,12 @@ urlpatterns = [
                         views.AnonymousFragmentDeleteView.as_view(),
                         name="delete",
                     ),
-                    path("<pk>/duplicate", views.duplicate_fragment, {"model_name":"anonymousfragment"}, name="duplicate"),
+                    path(
+                        "<pk>/duplicate",
+                        views.duplicate_fragment,
+                        {"model_name": "anonymousfragment"},
+                        name="duplicate",
+                    ),
                     path(
                         "<pk>/convert-to-fragment/",
                         views.AnonymousFragmentConvertToFragmentView.as_view(),

--- a/src/rard/research/urls.py
+++ b/src/rard/research/urls.py
@@ -296,6 +296,7 @@ urlpatterns = [
                         views.UnlinkedFragmentConvertToAnonymousView.as_view(),
                         name="convert_to_anonymous",
                     ),
+                    path("<pk>/duplicate", views.duplicate_fragment, name="duplicate"),
                     path("<pk>/", views.FragmentDetailView.as_view(), name="detail"),
                     path(
                         "<pk>/create-original-text/",

--- a/src/rard/research/urls.py
+++ b/src/rard/research/urls.py
@@ -369,6 +369,7 @@ urlpatterns = [
                         views.AnonymousFragmentDeleteView.as_view(),
                         name="delete",
                     ),
+                    path("<pk>/duplicate", views.duplicate_fragment, name="duplicate"),
                     path(
                         "<pk>/convert-to-fragment/",
                         views.AnonymousFragmentConvertToFragmentView.as_view(),

--- a/src/rard/research/urls.py
+++ b/src/rard/research/urls.py
@@ -296,7 +296,7 @@ urlpatterns = [
                         views.UnlinkedFragmentConvertToAnonymousView.as_view(),
                         name="convert_to_anonymous",
                     ),
-                    path("<pk>/duplicate", views.duplicate_fragment, name="duplicate"),
+                    path("<pk>/duplicate", views.duplicate_fragment, {"model_name":"fragment"}, name="duplicate"),
                     path("<pk>/", views.FragmentDetailView.as_view(), name="detail"),
                     path(
                         "<pk>/create-original-text/",
@@ -369,7 +369,7 @@ urlpatterns = [
                         views.AnonymousFragmentDeleteView.as_view(),
                         name="delete",
                     ),
-                    path("<pk>/duplicate", views.duplicate_fragment, name="duplicate"),
+                    path("<pk>/duplicate", views.duplicate_fragment, {"model_name":"anonymousfragment"}, name="duplicate"),
                     path(
                         "<pk>/convert-to-fragment/",
                         views.AnonymousFragmentConvertToFragmentView.as_view(),

--- a/src/rard/research/views/__init__.py
+++ b/src/rard/research/views/__init__.py
@@ -78,6 +78,7 @@ from .fragment import (
     RemoveFragmentLinkView,
     UnlinkedFragmentConvertToAnonymousView,
     UnlinkedFragmentListView,
+    duplicate_fragment,
     fetch_fragments,
 )
 from .history import HistoryListView
@@ -208,6 +209,7 @@ __all__ = [
     "FragmentUpdateWorkLinkView",
     "FragmentUpdateAntiquariansView",
     "fetch_fragments",
+    "duplicate_fragment",
     "HistoryListView",
     "HomeView",
     "MentionSearchView",

--- a/src/rard/research/views/fragment.py
+++ b/src/rard/research/views/fragment.py
@@ -1024,7 +1024,11 @@ def duplicate_fragment(request, pk):
     )
 
     # Get the original fragment
-    original_fragment = get_object_or_404(Fragment, pk=pk)
+
+    if "anonymous" in request.path:
+        original_fragment = get_object_or_404(AnonymousFragment, pk=pk)
+    else:
+        original_fragment = get_object_or_404(Fragment, pk=pk)
     original_original_texts = original_fragment.original_texts.all()
 
     new_original_texts = []
@@ -1122,6 +1126,8 @@ def duplicate_fragment(request, pk):
             "created",
             "modified",
             "commentary",
+            "order",  # anon frags have this
+            "model",
         ]:
             continue
 
@@ -1129,9 +1135,7 @@ def duplicate_fragment(request, pk):
 
         new_fragment_data[field.name] = field_value
 
-    new_fragment = Fragment.objects.create(
-        **new_fragment_data
-    )  # might need to specify anonfrag
+    new_fragment = Fragment.objects.create(**new_fragment_data)
     # Attach the original texts
     new_fragment.original_texts.set(new_original_texts)
 

--- a/src/rard/research/views/fragment.py
+++ b/src/rard/research/views/fragment.py
@@ -1118,7 +1118,6 @@ def duplicate_fragment(request, pk, model_name):
             "commentary",
             "plain_commentary",
             "order",  # anon frags have this
-            # "model",
         ]:
             continue
 

--- a/src/rard/research/views/fragment.py
+++ b/src/rard/research/views/fragment.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.context_processors import PermWrapper
 from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import BadRequest, ObjectDoesNotExist
 from django.db.models import F
 from django.http import (
@@ -33,10 +34,15 @@ from rard.research.forms import (
 from rard.research.models import (
     AnonymousFragment,
     Antiquarian,
+    ApparatusCriticusItem,
     CitingAuthor,
     CitingWork,
+    Concordance,
     Fragment,
+    OriginalText,
+    Reference,
     Topic,
+    Translation,
     Work,
 )
 from rard.research.models.base import AppositumFragmentLink, FragmentLink
@@ -1013,18 +1019,7 @@ def fetch_fragments(request):
 
 
 def duplicate_fragment(request, pk):
-    from django.contrib.contenttypes.models import ContentType
-
-    from rard.research.models import (
-        ApparatusCriticusItem,
-        Concordance,
-        OriginalText,
-        Reference,
-        Translation,
-    )
-
     # Get the original fragment
-
     if "anonymous" in request.path:
         original_fragment = get_object_or_404(AnonymousFragment, pk=pk)
     else:

--- a/src/rard/research/views/fragment.py
+++ b/src/rard/research/views/fragment.py
@@ -1129,12 +1129,13 @@ def duplicate_fragment(request, pk):
 
         new_fragment_data[field.name] = field_value
 
-    new_fragment = Fragment.objects.create(**new_fragment_data)
+    new_fragment = Fragment.objects.create(
+        **new_fragment_data
+    )  # might need to specify anonfrag
     # Attach the original texts
     new_fragment.original_texts.set(new_original_texts)
 
     # Duplicate relationships to topics
-    for topic in original_fragment.topics.all():
-        new_fragment.topics.add(topic)
+    new_fragment.topics.set(original_fragment.topics.all())
 
     return redirect("fragment:detail", pk=new_fragment.pk)

--- a/src/rard/research/views/fragment.py
+++ b/src/rard/research/views/fragment.py
@@ -1033,7 +1033,7 @@ def duplicate_fragment(request, pk):
         # Iterate over the fields of the OriginalText model
         for field in original_original_texts[i]._meta.fields:
             # Exclude the ID field
-            if field.name == "id":
+            if field.name in ["id", "created", "modified"]:
                 continue
 
             field_value = getattr(original_original_texts[i], field.name)
@@ -1074,9 +1074,25 @@ def duplicate_fragment(request, pk):
                 object_id=new_original_text.pk,
                 parent=new_original_text,
             )
-    # Create a new fragment with the same original text
-    new_fragment = Fragment.objects.create()
 
+    # Create a new fragment with the same values as original
+    new_fragment_data = {}
+    for field in original_fragment._meta.fields:
+        # Exclude unique fields
+        if field.name in [
+            "id",
+            "created",
+            "modified",
+            "commentary",
+        ]:
+            continue
+
+        field_value = getattr(original_fragment, field.name)
+
+        new_fragment_data[field.name] = field_value
+
+    new_fragment = Fragment.objects.create(**new_fragment_data)
+    # Attach the original texts
     new_fragment.original_texts.set(new_original_texts)
 
     # Duplicate relationships to topics

--- a/src/rard/research/views/fragment.py
+++ b/src/rard/research/views/fragment.py
@@ -1018,12 +1018,16 @@ def fetch_fragments(request):
     )
 
 
-def duplicate_fragment(request, pk):
+def duplicate_fragment(request, pk, model_name):
     # Get the original fragment
-    if "anonymous" in request.path:
+    if model_name == "anonymousfragment":
         original_fragment = get_object_or_404(AnonymousFragment, pk=pk)
-    else:
+
+    elif model_name == "fragment":
         original_fragment = get_object_or_404(Fragment, pk=pk)
+    else:
+        raise BadRequest("model name not recognised")
+
     original_original_texts = original_fragment.original_texts.all()
 
     new_original_texts = []

--- a/src/rard/templates/research/anonymousfragment_detail.html
+++ b/src/rard/templates/research/anonymousfragment_detail.html
@@ -41,7 +41,7 @@
                     >{% trans 'Make non-anonymous' %}</button>
                 </div>
             </form>
-            <form novalidate style='margin-left:auto' class='form-inline' action='{% url "fragment:duplicate" object.pk %}' method='POST'>
+            <form novalidate style='margin-left:auto' class='form-inline' action='{% url "anonymous_fragment:duplicate" object.pk %}' method='POST'>
                 {% csrf_token %}
                 <div class='form-group'>
                     <button type='submit' class='btn btn-link text-info p-0 ml-2'

--- a/src/rard/templates/research/anonymousfragment_detail.html
+++ b/src/rard/templates/research/anonymousfragment_detail.html
@@ -41,6 +41,13 @@
                     >{% trans 'Make non-anonymous' %}</button>
                 </div>
             </form>
+            <form novalidate style='margin-left:auto' class='form-inline' action='{% url "fragment:duplicate" object.pk %}' method='POST'>
+                {% csrf_token %}
+                <div class='form-group'>
+                    <button type='submit' class='btn btn-link text-info p-0 ml-2'
+                        data-what='fragment'>{% trans 'Duplicate' %}</button>
+                </div>
+            </form>
             {% endif %}
         </div>
         {% endif %}

--- a/src/rard/templates/research/anonymousfragment_detail.html
+++ b/src/rard/templates/research/anonymousfragment_detail.html
@@ -45,7 +45,7 @@
                 {% csrf_token %}
                 <div class='form-group'>
                     <button type='submit' class='btn btn-link text-info p-0 ml-2'
-                        data-what='fragment'>{% trans 'Duplicate' %}</button>
+                        data-what='anonymous fragment'>{% trans 'Duplicate' %}</button>
                 </div>
             </form>
             {% endif %}

--- a/src/rard/templates/research/fragment_detail.html
+++ b/src/rard/templates/research/fragment_detail.html
@@ -35,6 +35,14 @@
                 </div>
             </form>
             {% endif %}
+            <form novalidate style='margin-left:auto' class='form-inline' action='{% url "fragment:duplicate" fragment.pk %}' method='POST'>
+                {% csrf_token %}
+                <div class='form-group'>
+                    <button type='submit' class='btn btn-link text-info p-0 ml-2'
+                        data-what='fragment'>{% trans 'Duplicate' %}</button>
+                </div>
+            </form>
+
         </div>
       {% endif %}
     {% endwith %}


### PR DESCRIPTION
closes #393 
---
New view with button to duplicate the fragment. The duplication also duplicates the `OriginalText` and the `Concordance` instances associated, as well as `Topics`, `References`, `Translations` and `ApparatusCriticusItems`. 


The code loops through all the fields of the `OriginalText` and copies their values and goes through these associated models and does the same thing, then assigns the new `OriginalText` instance in place of the original one. Finally, the `Fragment` is copied and the new `OriginalText` attached, and then `Topics` are copied.

On the frontend, the `Duplicate` button is clicked, a request is sent to the view with the pk of the original item. Upon completion, the user is redirected to the new unlinked fragment.

The commentary and links/apposita are not copied over, intentionally.

This has been implemented for `Fragments and `AnonymousFragments`, unlinked `Fragments` are created in both cases (tbc)