### PR TITLE
Feature/shorten mentions

### DIFF
--- a/src/rard/research/models/bibliography.py
+++ b/src/rard/research/models/bibliography.py
@@ -25,6 +25,12 @@ class BibliographyItem(HistoryModelMixin, LockableModel, BaseModel):
     def get_absolute_url(self):
         return reverse("bibliography:detail", kwargs={"pk": self.pk})
 
+    def mention_citation(self):
+        r = self.author_surnames
+        if self.year:
+            r += " [" + self.year + "]"
+        return r.strip()
+
     class Meta:
         ordering = ["author_surnames", "year"]
 

--- a/src/rard/research/tests/models/test_bibliography.py
+++ b/src/rard/research/tests/models/test_bibliography.py
@@ -20,6 +20,10 @@ class TestBibliography(TestCase):
         # the __str__ function should show the name
         self.assertEqual(str(self.bibliography), "Hartley [1855]: Fly Fishing")
 
+    def test_mention_citation(self):
+        # the mention_citation function should show the name and year only
+        self.assertEqual(self.bibliography.mention_citation(), "Hartley [1855]")
+
     def test_creation(self):
         self.assertTrue(
             BibliographyItem.objects.filter(pk=self.bibliography.pk).exists()

--- a/src/rard/research/views/mention.py
+++ b/src/rard/research/views/mention.py
@@ -178,7 +178,9 @@ class MentionSearchView(LoginRequiredMixin, View):
             if not model_name:
                 model_name = next(k for k, value in dd.items() if value == o.__class__)
                 model_name_cache[o.__class__] = model_name
-            citation = o.mention_citation() if hasattr(o,"mention_citation") else str(o)
+            citation = (
+                o.mention_citation() if hasattr(o, "mention_citation") else str(o)
+            )
             ajax_data.append(
                 {
                     "id": o.pk,

--- a/src/rard/research/views/mention.py
+++ b/src/rard/research/views/mention.py
@@ -178,19 +178,15 @@ class MentionSearchView(LoginRequiredMixin, View):
             if not model_name:
                 model_name = next(k for k, value in dd.items() if value == o.__class__)
                 model_name_cache[o.__class__] = model_name
-            if model_name == "bibliographyitem":
-                ajax_data.append(
-                    {
-                        "id": o.pk,
-                        "target": model_name,
-                        "value": str(o),
-                        "citation": BibliographyItem.objects.get(
-                            pk=o.pk
-                        ).mention_citation(),
-                    }
-                )
-            else:
-                ajax_data.append({"id": o.pk, "target": model_name, "value": str(o)})
+            citation = o.mention_citation() if hasattr(o,"mention_citation") else str(o)
+            ajax_data.append(
+                {
+                    "id": o.pk,
+                    "target": model_name,
+                    "value": str(o),
+                    "citation": citation,
+                }
+            )
         return JsonResponse(data=ajax_data, safe=False)
 
     def parse_mention(self, q):

--- a/src/rard/research/views/mention.py
+++ b/src/rard/research/views/mention.py
@@ -178,8 +178,19 @@ class MentionSearchView(LoginRequiredMixin, View):
             if not model_name:
                 model_name = next(k for k, value in dd.items() if value == o.__class__)
                 model_name_cache[o.__class__] = model_name
-
-            ajax_data.append({"id": o.pk, "target": model_name, "value": str(o)})
+            if model_name == "bibliographyitem":
+                ajax_data.append(
+                    {
+                        "id": o.pk,
+                        "target": model_name,
+                        "value": str(o),
+                        "citation": BibliographyItem.objects.get(
+                            pk=o.pk
+                        ).mention_citation(),
+                    }
+                )
+            else:
+                ajax_data.append({"id": o.pk, "target": model_name, "value": str(o)})
         return JsonResponse(data=ajax_data, safe=False)
 
     def parse_mention(self, q):

--- a/src/rard/static/js/project.js
+++ b/src/rard/static/js/project.js
@@ -374,7 +374,14 @@ function initRichTextEditor($item) {
     $item.hasClass("enable-apparatus-criticus")
   ) {
     let delimiters = [];
-    let dataAttributes = ["id", "value", "denotationChar", "link", "target"];
+    let dataAttributes = [
+      "id",
+      "value",
+      "denotationChar",
+      "link",
+      "target",
+      "citation",
+    ];
     if ($item.hasClass("enable-mentions")) {
       delimiters.push("@");
     }
@@ -405,9 +412,17 @@ function initRichTextEditor($item) {
         }
       },
       renderItem(item, searchTerm) {
-        // allows you to control how the item is displayed
+        // allows you to control how the item is displayed in the list
         let list_display = item.list_display || item.value;
         return `${list_display}`;
+      },
+      onSelect(item, insertItem) {
+        if (item.citation) {
+          const shortItem = { ...item, value: item.citation };
+          insertItem(shortItem);
+        } else {
+          insertItem(item);
+        }
       },
     };
   }

--- a/src/rard/static/js/project.js
+++ b/src/rard/static/js/project.js
@@ -417,12 +417,8 @@ function initRichTextEditor($item) {
         return `${list_display}`;
       },
       onSelect(item, insertItem) {
-        if (item.citation) {
-          const shortItem = { ...item, value: item.citation };
-          insertItem(shortItem);
-        } else {
-          insertItem(item);
-        }
+        const shortItem = { ...item, value: item.citation };
+        insertItem(shortItem);
       },
     };
   }

--- a/src/rard/utils/basemodel.py
+++ b/src/rard/utils/basemodel.py
@@ -79,7 +79,7 @@ class DynamicTextField(TextField):
                             linked = model.objects.get(pk=int(pkstr))
 
                             if char == "@":
-                                if model_name == "bibliographyitem":
+                                if hasattr(linked, "mention_citation"):
                                     link_text = linked.mention_citation()
                                 else:
                                     link_text = str(linked)
@@ -163,7 +163,7 @@ class DynamicTextField(TextField):
                             linked = model.objects.get(pk=int(pkstr))
                             # is it something we can link to?
                             if getattr(linked, "get_absolute_url", False):
-                                if model_name == "bibliographyitem":
+                                if hasattr(linked, "mention_citation"):
                                     replacement = bs4.BeautifulSoup(
                                         '<a href="{}">{}</a>'.format(
                                             linked.get_absolute_url(),

--- a/src/rard/utils/basemodel.py
+++ b/src/rard/utils/basemodel.py
@@ -161,7 +161,6 @@ class DynamicTextField(TextField):
                                 app_label="research", model_name=model_name
                             )
                             linked = model.objects.get(pk=int(pkstr))
-                            print(linked.get_absolute_url())
                             # is it something we can link to?
                             if getattr(linked, "get_absolute_url", False):
                                 if model_name == "bibliographyitem":

--- a/src/rard/utils/basemodel.py
+++ b/src/rard/utils/basemodel.py
@@ -79,7 +79,10 @@ class DynamicTextField(TextField):
                             linked = model.objects.get(pk=int(pkstr))
 
                             if char == "@":
-                                link_text = str(linked)
+                                if model_name == "bibliographyitem":
+                                    link_text = linked.mention_citation()
+                                else:
+                                    link_text = str(linked)
                             else:
                                 # it's an apparatus criticus so we need
                                 # show its index and any ordinal relating
@@ -158,14 +161,24 @@ class DynamicTextField(TextField):
                                 app_label="research", model_name=model_name
                             )
                             linked = model.objects.get(pk=int(pkstr))
+                            print(linked.get_absolute_url())
                             # is it something we can link to?
                             if getattr(linked, "get_absolute_url", False):
-                                replacement = bs4.BeautifulSoup(
-                                    '<a href="{}">{}</a>'.format(
-                                        linked.get_absolute_url(), str(linked)
-                                    ),
-                                    features="html.parser",
-                                )
+                                if model_name == "bibliographyitem":
+                                    replacement = bs4.BeautifulSoup(
+                                        '<a href="{}">{}</a>'.format(
+                                            linked.get_absolute_url(),
+                                            str(linked.mention_citation()),
+                                        ),
+                                        features="html.parser",
+                                    )
+                                else:
+                                    replacement = bs4.BeautifulSoup(
+                                        '<a href="{}">{}</a>'.format(
+                                            linked.get_absolute_url(), str(linked)
+                                        ),
+                                        features="html.parser",
+                                    )
                             else:
                                 # else currently that means it's an
                                 # apparatus criticus item


### PR DESCRIPTION
closes #322 
---
- adds a new function to `BibliographyItem`s which gets passed in the mentions search
- mentions dropdown should display full version but the inserted version is the citation, which is what's persisted once in the editor (meaning the same when the object is saved and opened again for editing as other functions often change this)