### PR TITLE
Fix/429

### DIFF
--- a/src/rard/static/css/project.css
+++ b/src/rard/static/css/project.css
@@ -390,7 +390,7 @@ button.insert {
   background-color: #ffff00;
 }
 
-/* editor related */
+/****************** editor related *********************/
 .ql-editor {
   background-color: white !important;
   font-size: 18px;
@@ -408,6 +408,22 @@ button.insert {
 }
 .rich-editor {
   font-family: Alphabetum !important;
+}
+.rich-editor__wrapper {
+  min-height: 400px;
+  padding-bottom: 60px;
+}
+.rich-editor__wrapper--bibliography-title {
+  max-height: 100px;
+  min-height: 1px; /* this will take precedence over the generic one */
+
+  .ql-editor {
+    min-height: 0;
+  }
+}
+.rich-editor__wrapper--app-crit {
+  min-height: 30px;
+  padding-bottom: 30px;
 }
 .ql-editor .footnote-area {
   font-size: 80%;

--- a/src/rard/templates/research/base_create_form.html
+++ b/src/rard/templates/research/base_create_form.html
@@ -45,10 +45,6 @@
             {% include 'research/partials/rich_text_editor.html' with field=forms.original_text.content %}
             {% bootstrap_field forms.original_text.apparatus_criticus_blank %}
 
-            {% comment %}
-            {% bootstrap_field forms.original_text.apparatus_criticus field_class='d-none' %}
-            {% include 'research/partials/rich_text_editor.html' with field=forms.original_text.apparatus_criticus %}
-            {% endcomment %}
 
             {% for field in forms.object %}
                 {% bootstrap_field field %}

--- a/src/rard/templates/research/fragment_detail.html
+++ b/src/rard/templates/research/fragment_detail.html
@@ -160,23 +160,6 @@
 
     <section>
 
-        {% comment %} <div>
-            {% if perms.research.change_antiquarian and has_object_lock %}
-
-            <form novalidate enctype="multipart/form-data" autocomplete='off' action='{% url "fragment:update_commentary" object.pk %}' class="form" method='POST'>
-                {% csrf_token %}
-                    {% bootstrap_field form.commentary_text field_class='d-none' show_label=False %}
-                    {% include 'research/partials/rich_text_editor.html' with object_id=object.pk object_class='fragment' field=form.commentary_text enable_mentions=True enable_apparatus_criticus=True %}
-
-                <button type="submit" class="btn btn-primary inline-save-button">
-                        {% trans 'Save' %}
-                </button>
-                <a class='ml-3 inline-cancel-button' href='{% url "fragment:detail" object.pk %}'>{% trans 'Cancel' %}</a>
-            </form>
-
-            {% endif %}
-
-        </div> {% endcomment %}
 
         <div class='d-flex justify-content-between mb-3'>
             <div>

--- a/src/rard/templates/research/inline_forms/bibliographyitem_form.html
+++ b/src/rard/templates/research/inline_forms/bibliographyitem_form.html
@@ -14,7 +14,7 @@
     </div>
   </div>
   {% bootstrap_field form.title %}
-  {% include 'research/partials/rich_text_editor.html' with field=form.title enable_mentions=False max_height=100 min_height=1 extra_classes="bib-title mt-2" %}
+  {% include 'research/partials/rich_text_editor.html' with field=form.title enable_mentions=False extra_classes="rich-editor__wrapper--bibliography-title mt-2" %}
 
     {% comment %} {% bootstrap_field form.antiquarians %}
     {% bootstrap_field form.citing_authors %} {% endcomment %}

--- a/src/rard/templates/research/originaltext_form.html
+++ b/src/rard/templates/research/originaltext_form.html
@@ -55,26 +55,5 @@
     {% include 'research/partials/apparatus_criticus_builder.html' with form=forms.original_text original_text=object %}
     {% endif %}
 
-    {% comment %}
-    <div class='form-group'>
-        <label>Apparatus Criticus</label>
-        {% if object %}
-            <div><button type='button' data-index='0' class='show_apparatus_criticus_form btn btn-light btn-sm'>+</button></div>
-            {% for line in object.apparatus_criticus_lines %}
-            <div class='border-bottom: 1px solid'>{{ line.order }}<span class='ml-3'>{{ line.content|safe }}</span></div>
-            <div><button type='button' data-index='{{ forloop.counter }}' class='show_apparatus_criticus_form btn btn-light btn-sm'>+</button></div>
-            {% endfor %}
-        {% endif %}
-    </div>
-
-    <div id='new_apparatus_criticus_line_area' class='mt-3' style='display:none;'>
-        {% bootstrap_field forms.original_text.new_apparatus_criticus_line show_label=False %}
-        {% include 'research/partials/rich_text_editor.html' with min_height=30 padding_bottom=30 field=forms.original_text.new_apparatus_criticus_line %}
-        <div class='d-flex flex-row-reverse'>
-            <button type='button' id='cancel-new-apparatus-criticus-line' class=' btn btn-secondary btn-sm'>Cancel</button>
-            <button type='button' data-parent='{{ object.pk }}' data-action='{% url "create_apparatus_criticus_line" %}' id='submit-new-apparatus-criticus-line' class=' mx-2 btn btn-success btn-sm'>Add Line</button>
-        </div>
-    </div>
-    {% endcomment %}
 
 {% endblock %}

--- a/src/rard/templates/research/partials/apparatus_criticus_builder.html
+++ b/src/rard/templates/research/partials/apparatus_criticus_builder.html
@@ -84,7 +84,7 @@
 
     <div id='new_apparatus_criticus_line_area' class='mt-3' style='display:none;'>
         {% bootstrap_field form.new_apparatus_criticus_line show_label=False %}
-        {% include 'research/partials/rich_text_editor.html' with min_height=30 padding_bottom=30 field=form.new_apparatus_criticus_line %}
+        {% include 'research/partials/rich_text_editor.html' with extra_classes="rich-editor__wrapper--app-crit" field=form.new_apparatus_criticus_line %}
         <div class='d-flex flex-row-reverse'>
             <button type='button' id='cancel-new-apparatus-criticus-line' class=' btn btn-secondary btn-sm'>Cancel</button>
             <button type='button' data-parent='{{ original_text.pk }}' data-action='{% url "create_apparatus_criticus_line" %}' id='submit-new-apparatus-criticus-line' class=' mx-2 btn btn-success btn-sm'>Add Line</button>

--- a/src/rard/templates/research/partials/rich_text_editor.html
+++ b/src/rard/templates/research/partials/rich_text_editor.html
@@ -2,7 +2,7 @@
 {# assumes form field as a context variable named 'field' and whether to enable mentions 'enable_mentions' and optional min_height and padding_bottom in pixels #}
 
 <div class='row mb-3 mt-n3 editor-area'>
-    <div class='col h-fill {% if extra_classes %}{{extra_classes}}{% endif %}' style='min-height: {% if min_height %}{{ min_height }}{% else %}400{% endif %}px; max-height: {% if max_height %}{{ max_height }}px{% else %}auto{% endif %}; padding-bottom: {% if padding_bottom != None %}{{ padding_bottom }}{% else %}60{% endif %}px;'>
+    <div class='col h-fill rich-editor__wrapper {% if extra_classes %}{{extra_classes}}{% endif %}' >
         <div id='{{ field.auto_id }}_editor' {% if object_class %}data-class='{{ object_class }}'{% endif %} {% if object_id %}data-object='{{ object_id }}'{% endif %} class='rich-editor {% if enable_mentions %}enable-mentions{% endif %} {% if enable_apparatus_criticus %}enable-apparatus-criticus{% endif %}' spellcheck="false"  id='{{ field.auto_id }}_rich_editor_content' data-for='{{ field.auto_id }}' data-model-field='{{ field.name }}'>
         </div>
         <div class='text-muted'>


### PR DESCRIPTION
closes #429 
---
- have made a base class `rich-editor__wrapper` which utilises the defaults of the inline styling
- kept the `extra_classes` parameter for flexibility
- created classes for the instances where the default inline styling was overwritten and used them in `extra_classes`
- so long as any new classes are written in the CSS _after_ the `rich-editor__wrapper` they will take precedence in the attributes defined