### PR TITLE
Feature/consolidating edit menu

### DIFF
--- a/src/rard/static/css/project.css
+++ b/src/rard/static/css/project.css
@@ -390,14 +390,6 @@ button.insert {
   background-color: #ffff00;
 }
 
-.lock-duration {
-  display: none;
-}
-
-.lock-options:hover .lock-duration {
-  display: block;
-}
-
 /* editor related */
 .ql-editor {
   background-color: white !important;

--- a/src/rard/static/css/project.css
+++ b/src/rard/static/css/project.css
@@ -390,6 +390,14 @@ button.insert {
   background-color: #ffff00;
 }
 
+.unlock-duration {
+  display: none;
+}
+
+.unlock-options:hover .unlock-duration {
+  display: block;
+}
+
 /* editor related */
 .ql-editor {
   background-color: white !important;

--- a/src/rard/static/css/project.css
+++ b/src/rard/static/css/project.css
@@ -390,11 +390,11 @@ button.insert {
   background-color: #ffff00;
 }
 
-.unlock-duration {
+.lock-duration {
   display: none;
 }
 
-.unlock-options:hover .unlock-duration {
+.lock-options:hover .lock-duration {
   display: block;
 }
 

--- a/src/rard/templates/research/anonymousfragment_detail.html
+++ b/src/rard/templates/research/anonymousfragment_detail.html
@@ -15,7 +15,6 @@
     {% with request.user|has_lock:object as has_object_lock %}
 
         {% include 'research/partials/render_locked_info.html' with is_anonymousfragment="anonymous fragment" %}
-
     {% endwith %}
 {% endblock %}
 

--- a/src/rard/templates/research/anonymousfragment_detail.html
+++ b/src/rard/templates/research/anonymousfragment_detail.html
@@ -14,7 +14,7 @@
 {% block action %}
     {% with request.user|has_lock:object as has_object_lock %}
 
-        {% include 'research/partials/render_locked_info.html' %}
+        {% include 'research/partials/render_locked_info.html' with is_anonymousfragment=True %}
 
         {% if has_object_lock %}
         <div class='d-flex flex-column justify-content-end'>

--- a/src/rard/templates/research/anonymousfragment_detail.html
+++ b/src/rard/templates/research/anonymousfragment_detail.html
@@ -14,7 +14,7 @@
 {% block action %}
     {% with request.user|has_lock:object as has_object_lock %}
 
-        {% include 'research/partials/render_locked_info.html' with is_anonymousfragment=True %}
+        {% include 'research/partials/render_locked_info.html' with is_anonymousfragment="anonymous fragment" %}
 
     {% endwith %}
 {% endblock %}

--- a/src/rard/templates/research/anonymousfragment_detail.html
+++ b/src/rard/templates/research/anonymousfragment_detail.html
@@ -16,41 +16,6 @@
 
         {% include 'research/partials/render_locked_info.html' with is_anonymousfragment=True %}
 
-        {% if has_object_lock %}
-        <div class='d-flex flex-column justify-content-end'>
-            {% if perms.research.delete_anonymousfragment %}
-            <form novalidate style='margin-left:auto' class='form-inline' action='{% url "anonymous_fragment:delete" object.pk %}' method='POST'>
-                {% csrf_token %}
-                <div class='form-group'>
-                    <button type='submit' class='btn btn-link text-danger {% if object.mentioned_in.all %}confirm-delete-mentions {% else %} confirm-delete {% endif %} p-0 ml-2'
-                        data-what='anonymous fragment'>{% trans 'Delete' %}</button>
-                </div>
-            </form>
-            {% endif %}
-            {% if perms.research.change_anonymousfragment %}
-            <form novalidate style='margin-left:auto' class='form-inline' action='{% url "anonymous_fragment:convert_to_fragment" object.pk %}' method='POST'>
-                {% csrf_token %}
-                <div class='form-group'>
-                    <button
-                      type='submit'
-                      class='
-                      {% if object.get_all_links %}has-links{% endif %}
-                      btn btn-link text-danger confirm-convert p-0 ml-2
-                      '
-                      data-what='anonymous fragment'
-                    >{% trans 'Make non-anonymous' %}</button>
-                </div>
-            </form>
-            <form novalidate style='margin-left:auto' class='form-inline' action='{% url "anonymous_fragment:duplicate" object.pk %}' method='POST'>
-                {% csrf_token %}
-                <div class='form-group'>
-                    <button type='submit' class='btn btn-link text-info p-0 ml-2'
-                        data-what='anonymous fragment'>{% trans 'Duplicate' %}</button>
-                </div>
-            </form>
-            {% endif %}
-        </div>
-        {% endif %}
     {% endwith %}
 {% endblock %}
 

--- a/src/rard/templates/research/antiquarian_detail.html
+++ b/src/rard/templates/research/antiquarian_detail.html
@@ -16,21 +16,8 @@
 
     {% with request.user|has_lock:object as has_object_lock %}
 
-        {% include 'research/partials/render_locked_info.html' %}
+        {% include 'research/partials/render_locked_info.html' with is_antiquarian="antiquarian" %}
 
-        <div class='d-flex justify-content-end'>
-            {% if has_object_lock %}
-                {% if perms.research.delete_antiquarian %}
-                    <form novalidate class='form-inline' action='{% url "antiquarian:delete" antiquarian.pk %}' method='POST'>
-                        {% csrf_token %}
-                        <div class='form-group'>
-                            <button type='submit' class='btn btn-link text-danger confirm-delete p-0 ml-2'
-                                data-what='antiquarian'>{% trans 'Delete' %}</button>
-                        </div>
-                    </form>
-                {% endif %}
-            {% endif %}
-        </div>
     {% endwith %}
 
 {% endblock %}

--- a/src/rard/templates/research/base.html
+++ b/src/rard/templates/research/base.html
@@ -94,6 +94,10 @@
         {% trans 'Search' %}
       </a>
     </nav>
+    {% if user.is_authenticated %}
+    <hr>
+    <a class='nav-link' href="https://github.com/UCL/frrant/wiki">{% trans 'Docs' %}</a>
+    {% endif %}
   </div>
   <div class='col-md-10 main-content'>
     {% block outer %}

--- a/src/rard/templates/research/fragment_detail.html
+++ b/src/rard/templates/research/fragment_detail.html
@@ -15,36 +15,6 @@
 
         {% include 'research/partials/render_locked_info.html' with is_fragment=True %}
 
-        {% if has_object_lock %}
-        <div class='d-flex flex-column justify-content-end'>
-          {% if perms.research.delete_fragment %}
-            <form novalidate style='margin-left:auto' class='form-inline' action='{% url "fragment:delete" fragment.pk %}' method='POST'>
-                {% csrf_token %}
-                <div class='form-group'>
-                    <button type='submit' class='btn btn-link text-danger {% if object.mentioned_in.all %}confirm-delete-mentions {% else %} confirm-delete {% endif %} p-0 ml-2'
-                        data-what='fragment'>{% trans 'Delete' %}</button>
-                </div>
-            </form>
-          {% endif %}
-          {% if perms.research.change_fragment and object.is_unlinked %}
-            <form novalidate style='margin-left:auto' class='form-inline' action='{% url "fragment:convert_to_anonymous" fragment.pk %}' method='POST'>
-                {% csrf_token %}
-                <div class='form-group'>
-                    <button type='submit' class='btn btn-link text-danger confirm-convert p-0 ml-2'
-                        data-what='fragment'>{% trans 'Make anonymous' %}</button>
-                </div>
-            </form>
-            {% endif %}
-            <form novalidate style='margin-left:auto' class='form-inline' action='{% url "fragment:duplicate" fragment.pk %}' method='POST'>
-                {% csrf_token %}
-                <div class='form-group'>
-                    <button type='submit' class='btn btn-link text-info p-0 ml-2'
-                        data-what='fragment'>{% trans 'Duplicate' %}</button>
-                </div>
-            </form>
-
-        </div>
-      {% endif %}
     {% endwith %}
 {% endblock %}
 
@@ -57,13 +27,6 @@
         <div class='d-flex justify-content-between mb-3'>
             <div>
                 <h5>{% trans 'Details' %}</h5>
-            </div>
-            <div>
-                {% comment %}
-                {% if perms.research.change_fragment and has_object_lock %}
-                <a href='{% url "fragment:update" object.pk %}'>{% trans 'Edit' %}</a>
-                {% endif %}
-                {% endcomment %}
             </div>
         </div>
 

--- a/src/rard/templates/research/fragment_detail.html
+++ b/src/rard/templates/research/fragment_detail.html
@@ -13,7 +13,7 @@
 {% block action %}
     {% with request.user|has_lock:object as has_object_lock %}
 
-        {% include 'research/partials/render_locked_info.html' with is_fragment=True %}
+        {% include 'research/partials/render_locked_info.html' with is_fragment="fragment" %}
 
     {% endwith %}
 {% endblock %}

--- a/src/rard/templates/research/fragment_detail.html
+++ b/src/rard/templates/research/fragment_detail.html
@@ -13,7 +13,7 @@
 {% block action %}
     {% with request.user|has_lock:object as has_object_lock %}
 
-        {% include 'research/partials/render_locked_info.html' %}
+        {% include 'research/partials/render_locked_info.html' with is_fragment=True %}
 
         {% if has_object_lock %}
         <div class='d-flex flex-column justify-content-end'>

--- a/src/rard/templates/research/partials/render_locked_info.html
+++ b/src/rard/templates/research/partials/render_locked_info.html
@@ -74,7 +74,7 @@
                         <hr class="m-1">
 
                         {% if object.locked_by == request.user %}
-                        <button type='submit' class='btn btn-link text-primary' name='unlock'>Unlock</button>
+                        <button type='submit' class='btn btn-link text-primary' name='unlock'>Finish Editing</button>
 
                         {% else %}
                             {% if object.is_locked %}
@@ -85,7 +85,7 @@
 
                             {% elif not object.is_locked %}
                             <div class="lock-options">
-                                <button type='button' name='lock'  class='dropdown-toggle btn btn-link text-primary w-100 p-1 m-1'>Create Editing Lock</button>
+                                <button type='button' name='lock'  class='dropdown-toggle btn btn-link text-primary w-100 p-1 m-1'>Edit</button>
                                 <div class="lock-duration form-group">
                                     <button type='submit' name='days' value='1' class='dropdown-item'>for 1 day</button>
                                     <button type='submit' name='days' value='2' class='dropdown-item'>for 2 days</button>

--- a/src/rard/templates/research/partials/render_locked_info.html
+++ b/src/rard/templates/research/partials/render_locked_info.html
@@ -2,7 +2,7 @@
 
 {% load humanize object_lock i18n %}
 
-    <div class='align-items-center mb-2'>
+    <div class='d-flex justify-content-between align-items-center mb-2'>
         <div class='mr-3'>
 
             {% include 'research/partials/render_locked_icons.html' %}
@@ -19,7 +19,7 @@
                     </a>
 
                     <div class="dropdown-menu text-center p-2" aria-labelledby="dropdownMenuLink">
-                        <form novalidate class='form-group'  action='{% if is_testimonium %}{% url "testimonium:delete" testimonium.pk %} {% elif is_work %}{% url "work:delete" work.pk %} {% elif is_antiquarian %}{% url "antiquarian:delete" antiquarian.pk %}{% elif is_anonymousfragment %}{% url "anonymous_fragment:delete" object.pk %}% elif is_fragment %}{% url "fragment:delete" object.pk %}
+                        <form novalidate class='form-group'  action='{% if is_testimonium %}{% url "testimonium:delete" testimonium.pk %} {% elif is_work %}{% url "work:delete" work.pk %} {% elif is_antiquarian %}{% url "antiquarian:delete" antiquarian.pk %}{% elif is_anonymousfragment %}{% url "anonymous_fragment:delete" object.pk %}{% elif is_fragment %}{% url "fragment:delete" object.pk %}
                         {% endif %}'
                             method='POST'>
                             {% csrf_token %}
@@ -60,8 +60,12 @@
                         </form>
 
                         {% endif %}
-                        <hr>
-                    <button type='submit' class='btn btn-link text-primary btn-sm' name='unlock'>Finish&nbsp;Editing</button>
+
+                        <hr class="m-1">
+
+                        <button type='submit' class='btn btn-link text-primary' name='unlock'>Finish Editing</button>
+                    </div>
+                </div>
                 {% else %}
                     {% if object.is_locked %}
                         <button type='submit' class='btn btn-warning btn-sm' name='request'>Request Item</button>
@@ -76,12 +80,10 @@
                         </a>
 
                         <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
-                                <div class="lock-duration">
-                                    <button type='submit' name='days' value='1' class='dropdown-item'>for 1 day</button>
-                                    <button type='submit' name='days' value='2' class='dropdown-item'>for 2 days</button>
-                                    <button type='submit' name='days' value='7' class='dropdown-item'>for a week</button>
-                                    <button type='submit' name='lock' class='dropdown-item'>until I unlock</button>
-                                </div>
+                            <button type='submit' name='days' value='1' class='dropdown-item'>for 1 day</button>
+                            <button type='submit' name='days' value='2' class='dropdown-item'>for 2 days</button>
+                            <button type='submit' name='days' value='7' class='dropdown-item'>for a week</button>
+                            <button type='submit' name='lock' class='dropdown-item'>until I unlock</button>
                         </div>
                     </div>
                     {% endif %}

--- a/src/rard/templates/research/partials/render_locked_info.html
+++ b/src/rard/templates/research/partials/render_locked_info.html
@@ -2,7 +2,7 @@
 
 {% load humanize object_lock i18n %}
 
-    <div class='d-flex justify-content-between align-items-center mb-2'>
+    <div class='d-flex align-items-center mb-2'>
         <div class='mr-3'>
 
             {% include 'research/partials/render_locked_icons.html' %}
@@ -12,88 +12,92 @@
             <form novalidate enctype="multipart/form-data" autocomplete='off' action='{{ request.path }}' class="form"
                 method='POST'>
                 {% csrf_token %}
-                {% if object.locked_by == request.user %}
-                    <button type='submit' class='btn btn-primary btn-sm' name='unlock'>Finish&nbsp;Editing</button>
-                {% else %}
-                    {% if object.is_locked %}
-                        <button type='submit' class='btn btn-warning btn-sm' name='request'>Request Item</button>
-                        {% if request.user.can_break_locks %}
-                            <button title='You can break this lock'  type='submit' class='btn btn-danger btn-sm' name='break'><i class='fa fa-unlock'></i> Unlock</button>
-                        {% endif %}
-                    {% elif not object.is_locked %}
+                <div class="dropdown show">
+                    <a class="btn btn-primary btn-sm dropdown-toggle" name='lock' href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        Actions
+                    </a>
 
-                    <div class="dropdown show">
-                        <a class="btn btn-primary btn-sm dropdown-toggle" name='lock' href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                            Actions
-                        </a>
+                    <div class="dropdown-menu text-center p-2" aria-labelledby="dropdownMenuLink">
 
-                        <div class="dropdown-menu text-center p-2" aria-labelledby="dropdownMenuLink">
+                        {% if is_anonymousfragment %}
+                        <form novalidate  class='form-group mb-0' action='{% url "anonymous_fragment:delete" object.pk %}' method='POST'>
+                            {% csrf_token %}
+                            <button type='submit' class='btn btn-link text-danger {% if object.mentioned_in.all %}confirm-delete-mentions {% else %} confirm-delete {% endif %}'
+                                data-what='anonymous fragment'>{% trans 'Delete' %}</button>
+                        </form>
+                        <form novalidate class='form-group mb-0' action='{% url "anonymous_fragment:convert_to_fragment" object.pk %}' method='POST'>
+                            {% csrf_token %}
+                            <button
+                            type='submit'
+                            class='
+                            {% if object.get_all_links %}has-links{% endif %}
+                            btn btn-link text-danger confirm-convert p-1 text-nowrap
+                            '
+                            data-what='anonymous fragment'
+                            >{% trans 'Make non-anonymous' %}</button>
+                        </form>
+                        <form novalidate class='form-group mb-0' action='{% url "anonymous_fragment:duplicate" object.pk %}' method='POST'>
+                            {% csrf_token %}
+                            <button type='submit' class='btn btn-link text-info'
+                                data-what='anonymous fragment'>{% trans 'Duplicate' %}</button>
+                        </form>
 
-                            {% if is_anonymousfragment %}
-                            <form novalidate  class='form-group mb-0' action='{% url "anonymous_fragment:delete" object.pk %}' method='POST'>
+                        {% elif is_fragment %}
+                        <form novalidate  class='form-group mb-0' action='{% url "fragment:delete" object.pk %}' method='POST'>
+                            {% csrf_token %}
+                            <button type='submit' class='btn btn-link text-danger {% if object.mentioned_in.all %}confirm-delete-mentions {% else %} confirm-delete {% endif %}'
+                                data-what=' fragment'>{% trans 'Delete' %}</button>
+                        </form>
+                            {% if object.is_unlinked %}
+                            <form novalidate class='form-group mb-0' action='{% url "fragment:convert_to_anonymous" fragment.pk %}' method='POST'>
                                 {% csrf_token %}
-                                <button type='submit' class='btn btn-link text-danger {% if object.mentioned_in.all %}confirm-delete-mentions {% else %} confirm-delete {% endif %}'
-                                    data-what='anonymous fragment'>{% trans 'Delete' %}</button>
-                            </form>
-                            <form novalidate class='form-group mb-0' action='{% url "anonymous_fragment:convert_to_fragment" object.pk %}' method='POST'>
-                                {% csrf_token %}
-                                <button
-                                type='submit'
-                                class='
-                                {% if object.get_all_links %}has-links{% endif %}
-                                btn btn-link text-danger confirm-convert p-1 text-nowrap
-                                '
-                                data-what='anonymous fragment'
-                                >{% trans 'Make non-anonymous' %}</button>
-                            </form>
-                            <form novalidate class='form-group mb-0' action='{% url "anonymous_fragment:duplicate" object.pk %}' method='POST'>
-                                {% csrf_token %}
-                                <button type='submit' class='btn btn-link text-info'
-                                    data-what='anonymous fragment'>{% trans 'Duplicate' %}</button>
-                            </form>
-                            {% elif is_fragment %}
-                            <form novalidate  class='form-group mb-0' action='{% url "fragment:delete" object.pk %}' method='POST'>
-                                {% csrf_token %}
-                                <button type='submit' class='btn btn-link text-danger {% if object.mentioned_in.all %}confirm-delete-mentions {% else %} confirm-delete {% endif %}'
-                                    data-what=' fragment'>{% trans 'Delete' %}</button>
-                            </form>
-                                {% if object.is_unlinked %}
-                                <form novalidate class='form-group mb-0' action='{% url "fragment:convert_to_anonymous" fragment.pk %}' method='POST'>
-                                    {% csrf_token %}
-                                    <button type='submit' class='btn btn-link text-danger text-nowrap confirm-convert'
-                                        data-what='fragment'>{% trans 'Make anonymous' %}</button>
-                                </form>
-                                {% endif %}
-                            <form novalidate class='form-group mb-0' action='{% url "fragment:duplicate" object.pk %}' method='POST'>
-                                {% csrf_token %}
-                                <button type='submit' class='btn btn-link text-info'
-                                    data-what='fragment'>{% trans 'Duplicate' %}</button>
-                            </form>
-                            {% else %}
-                            <form novalidate class='form-group'  action='{% if is_testimonium %}{% url "testimonium:delete" testimonium.pk %} {% elif is_work %}{% url "work:delete" work.pk %} {% elif is_antiquarian %}{% url "antiquarian:delete" antiquarian.pk %}
-                            {% endif %}'
-                             method='POST'>
-                                {% csrf_token %}
-                                <button type='submit' class='btn btn-link text-danger {% if object.mentioned_in.all %}confirm-delete-mentions {% else %} confirm-delete {% endif %}'
-                                    data-what='{{is_testimonium}}{{is_work}}{{is_antiquarian}}'>{% trans 'Delete' %}</button>
+                                <button type='submit' class='btn btn-link text-danger text-nowrap confirm-convert'
+                                    data-what='fragment'>{% trans 'Make anonymous' %}</button>
                             </form>
                             {% endif %}
+                        <form novalidate class='form-group mb-0' action='{% url "fragment:duplicate" object.pk %}' method='POST'>
+                            {% csrf_token %}
+                            <button type='submit' class='btn btn-link text-info'
+                                data-what='fragment'>{% trans 'Duplicate' %}</button>
+                        </form>
 
-                            <hr class="m-1">
-                            <div class="unlock-options">
-                                <button type='button' name='unlock'  class='dropdown-toggle btn btn-link text-primary w-100 p-1 m-1'>Unlock</button>
-                                <div class="unlock-duration form-group">
+                        {% else %}
+                        <form novalidate class='form-group'  action='{% if is_testimonium %}{% url "testimonium:delete" testimonium.pk %} {% elif is_work %}{% url "work:delete" work.pk %} {% elif is_antiquarian %}{% url "antiquarian:delete" antiquarian.pk %}
+                        {% endif %}'
+                            method='POST'>
+                            {% csrf_token %}
+                            <button type='submit' class='btn btn-link text-danger {% if object.mentioned_in.all %}confirm-delete-mentions {% else %} confirm-delete {% endif %}'
+                                data-what='{{is_testimonium}}{{is_work}}{{is_antiquarian}}'>{% trans 'Delete' %}</button>
+                        </form>
+                        {% endif %}
+
+                        <hr class="m-1">
+
+                        {% if object.locked_by == request.user %}
+                        <button type='submit' class='btn btn-link text-primary' name='unlock'>Unlock</button>
+
+                        {% else %}
+                            {% if object.is_locked %}
+                            <button type='submit' class='btn btn-link text-warning' name='request'>Request Item</button>
+                                {% if request.user.can_break_locks %}
+                                    <button title='You can break this lock'  type='submit' class='btn btn-link text-danger' name='break'><i class='fa fa-unlock'></i> Unlock</button>
+                                {% endif %}
+
+                            {% elif not object.is_locked %}
+                            <div class="lock-options">
+                                <button type='button' name='lock'  class='dropdown-toggle btn btn-link text-primary w-100 p-1 m-1'>Create Editing Lock</button>
+                                <div class="lock-duration form-group">
                                     <button type='submit' name='days' value='1' class='dropdown-item'>for 1 day</button>
                                     <button type='submit' name='days' value='2' class='dropdown-item'>for 2 days</button>
                                     <button type='submit' name='days' value='7' class='dropdown-item'>for a week</button>
                                     <button type='submit' name='lock' class='dropdown-item text-danger'>until I unlock</button>
                                 </div>
                             </div>
-                        </div>
+                            {% endif %}
+                        {% endif %}
                     </div>
-                    {% endif %}
+                </div>
 
-                {% endif %}
             </form>
         </div>
     </div>

--- a/src/rard/templates/research/partials/render_locked_info.html
+++ b/src/rard/templates/research/partials/render_locked_info.html
@@ -24,56 +24,49 @@
 
                     <div class="dropdown show">
                         <a class="btn btn-primary btn-sm dropdown-toggle" name='lock' href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                            Edit
+                            Actions
                         </a>
 
-                        <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
+                        <div class="dropdown-menu text-center p-2" aria-labelledby="dropdownMenuLink">
 
                             {% if object.is_unlinked %}
-                            <form novalidate style='margin-left:auto' class='form-inline' action='{% url "fragment:convert_to_anonymous" fragment.pk %}' method='POST'>
-                                {% csrf_token %}
-                                <div class='form-group'>
-                                    <button type='submit' class='btn btn-link text-danger confirm-convert p-0 ml-1'
+                                <form novalidate class='form-group' action='{% url "fragment:convert_to_anonymous" fragment.pk %}' method='POST'>
+                                    {% csrf_token %}
+                                    <button type='submit' class='btn btn-link text-danger text-nowrap confirm-convert'
                                         data-what='fragment'>{% trans 'Make anonymous' %}</button>
-                                </div>
-                            </form>
+                                </form>
                             {% endif %}
                             {% if is_anonymousfragment %}
-                            <form novalidate style='margin-left:auto' class='form-inline' action='{% url "anonymous_fragment:convert_to_fragment" object.pk %}' method='POST'>
-                                {% csrf_token %}
-                                <button
-                                type='submit'
-                                class='
-                                {% if object.get_all_links %}has-links{% endif %}
-                                btn btn-link text-danger confirm-convert p-0
-                                '
-                                data-what='anonymous fragment'
-                                >{% trans 'Make non-anonymous' %}</button>
-                            </form>
-                            <form novalidate class='form-inline' action='{% url "anonymous_fragment:duplicate" object.pk %}' method='POST'>
-                                {% csrf_token %}
-                                <div class='form-group'>
-                                    <button type='submit' class='btn btn-link text-info p-0 pl-2'
+                                <form novalidate class='form-group' action='{% url "anonymous_fragment:convert_to_fragment" object.pk %}' method='POST'>
+                                    {% csrf_token %}
+                                    <button
+                                    type='submit'
+                                    class='
+                                    {% if object.get_all_links %}has-links{% endif %}
+                                    btn btn-link text-danger confirm-convert p-1 text-nowrap
+                                    '
+                                    data-what='anonymous fragment'
+                                    >{% trans 'Make non-anonymous' %}</button>
+                                </form>
+                                <form novalidate class='form-group mb-0' action='{% url "anonymous_fragment:duplicate" object.pk %}' method='POST'>
+                                    {% csrf_token %}
+                                    <button type='submit' class='btn btn-link text-info'
                                         data-what='anonymous fragment'>{% trans 'Duplicate' %}</button>
-                                </div>
-                            </form>
+                                </form>
                             {% endif %}
                             {% if is_fragment %}
-                            <form novalidate class='form-inline' action='{% url "fragment:duplicate" fragment.pk %}' method='POST'>
-                                {% csrf_token %}
-                                <div class='form-group'>
-                                    <button type='submit' class='btn btn-link text-info p-0 pl-2'
+                                <form novalidate class='form-group mb-0' action='{% url "fragment:duplicate" object.pk %}' method='POST'>
+                                    {% csrf_token %}
+                                    <button type='submit' class='btn btn-link text-info'
                                         data-what='fragment'>{% trans 'Duplicate' %}</button>
-                                </div>
-                            </form>
+                                </form>
                             {% endif %}
-
+                            <hr class="m-1">
                             <div class="unlock-options">
-                                <button type='button' name='unlock'  class='dropdown-toggle btn btn-info'>Unlock</button>
-                                <div class="unlock-duration">
+                                <button type='button' name='unlock'  class='dropdown-toggle btn btn-link text-primary w-100 p-1 m-1'>Unlock</button>
+                                <div class="unlock-duration form-group">
                                     <button type='submit' name='days' value='1' class='dropdown-item'>for 1 day</button>
                                     <button type='submit' name='days' value='2' class='dropdown-item'>for 2 days</button>
-                                    <button type='submit' name='days' value='5' class='dropdown-item'>for 5 days</button>
                                     <button type='submit' name='days' value='7' class='dropdown-item'>for a week</button>
                                     <button type='submit' name='lock' class='dropdown-item'>until I unlock</button>
                                 </div>

--- a/src/rard/templates/research/partials/render_locked_info.html
+++ b/src/rard/templates/research/partials/render_locked_info.html
@@ -18,13 +18,15 @@
                     </a>
 
                     <div class="dropdown-menu text-center p-2" aria-labelledby="dropdownMenuLink">
-
-                        {% if is_anonymousfragment %}
-                        <form novalidate  class='form-group mb-0' action='{% url "anonymous_fragment:delete" object.pk %}' method='POST'>
+                        <form novalidate class='form-group'  action='{% if is_testimonium %}{% url "testimonium:delete" testimonium.pk %} {% elif is_work %}{% url "work:delete" work.pk %} {% elif is_antiquarian %}{% url "antiquarian:delete" antiquarian.pk %}{% elif is_anonymousfragment %}{% url "anonymous_fragment:delete" object.pk %}% elif is_fragment %}{% url "fragment:delete" object.pk %}
+                        {% endif %}'
+                            method='POST'>
                             {% csrf_token %}
                             <button type='submit' class='btn btn-link text-danger {% if object.mentioned_in.all %}confirm-delete-mentions {% else %} confirm-delete {% endif %}'
-                                data-what='anonymous fragment'>{% trans 'Delete' %}</button>
+                                data-what='{{is_testimonium}}{{is_work}}{{is_antiquarian}}{{is_anonymousfragment}}{{is_fragment}}'>{% trans 'Delete' %}</button>
                         </form>
+
+                        {% if is_anonymousfragment %}
                         <form novalidate class='form-group mb-0' action='{% url "anonymous_fragment:convert_to_fragment" object.pk %}' method='POST'>
                             {% csrf_token %}
                             <button
@@ -43,11 +45,6 @@
                         </form>
 
                         {% elif is_fragment %}
-                        <form novalidate  class='form-group mb-0' action='{% url "fragment:delete" object.pk %}' method='POST'>
-                            {% csrf_token %}
-                            <button type='submit' class='btn btn-link text-danger {% if object.mentioned_in.all %}confirm-delete-mentions {% else %} confirm-delete {% endif %}'
-                                data-what=' fragment'>{% trans 'Delete' %}</button>
-                        </form>
                             {% if object.is_unlinked %}
                             <form novalidate class='form-group mb-0' action='{% url "fragment:convert_to_anonymous" fragment.pk %}' method='POST'>
                                 {% csrf_token %}
@@ -61,14 +58,6 @@
                                 data-what='fragment'>{% trans 'Duplicate' %}</button>
                         </form>
 
-                        {% else %}
-                        <form novalidate class='form-group'  action='{% if is_testimonium %}{% url "testimonium:delete" testimonium.pk %} {% elif is_work %}{% url "work:delete" work.pk %} {% elif is_antiquarian %}{% url "antiquarian:delete" antiquarian.pk %}
-                        {% endif %}'
-                            method='POST'>
-                            {% csrf_token %}
-                            <button type='submit' class='btn btn-link text-danger {% if object.mentioned_in.all %}confirm-delete-mentions {% else %} confirm-delete {% endif %}'
-                                data-what='{{is_testimonium}}{{is_work}}{{is_antiquarian}}'>{% trans 'Delete' %}</button>
-                        </form>
                         {% endif %}
 
                         <hr class="m-1">

--- a/src/rard/templates/research/partials/render_locked_info.html
+++ b/src/rard/templates/research/partials/render_locked_info.html
@@ -1,6 +1,6 @@
 {# Assumes a context object named 'object' which is a LockableModel instance #}
 
-{% load humanize object_lock %}
+{% load humanize object_lock i18n %}
 
     <div class='d-flex justify-content-between align-items-center mb-2'>
         <div class='mr-3'>
@@ -28,11 +28,56 @@
                         </a>
 
                         <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
-                            <button type='submit' name='days' value='1' class='dropdown-item'>for 1 day</button>
-                            <button type='submit' name='days' value='2' class='dropdown-item'>for 2 days</button>
-                            <button type='submit' name='days' value='5' class='dropdown-item'>for 5 days</button>
-                            <button type='submit' name='days' value='7' class='dropdown-item'>for a week</button>
-                            <button type='submit' name='lock' class='dropdown-item'>until I unlock</button>
+
+                            {% if object.is_unlinked %}
+                            <form novalidate style='margin-left:auto' class='form-inline' action='{% url "fragment:convert_to_anonymous" fragment.pk %}' method='POST'>
+                                {% csrf_token %}
+                                <div class='form-group'>
+                                    <button type='submit' class='btn btn-link text-danger confirm-convert p-0 ml-1'
+                                        data-what='fragment'>{% trans 'Make anonymous' %}</button>
+                                </div>
+                            </form>
+                            {% endif %}
+                            {% if is_anonymousfragment %}
+                            <form novalidate style='margin-left:auto' class='form-inline' action='{% url "anonymous_fragment:convert_to_fragment" object.pk %}' method='POST'>
+                                {% csrf_token %}
+                                <button
+                                type='submit'
+                                class='
+                                {% if object.get_all_links %}has-links{% endif %}
+                                btn btn-link text-danger confirm-convert p-0
+                                '
+                                data-what='anonymous fragment'
+                                >{% trans 'Make non-anonymous' %}</button>
+                            </form>
+                            <form novalidate class='form-inline' action='{% url "anonymous_fragment:duplicate" object.pk %}' method='POST'>
+                                {% csrf_token %}
+                                <div class='form-group'>
+                                    <button type='submit' class='btn btn-link text-info p-0 pl-2'
+                                        data-what='anonymous fragment'>{% trans 'Duplicate' %}</button>
+                                </div>
+                            </form>
+                            {% endif %}
+                            {% if is_fragment %}
+                            <form novalidate class='form-inline' action='{% url "fragment:duplicate" fragment.pk %}' method='POST'>
+                                {% csrf_token %}
+                                <div class='form-group'>
+                                    <button type='submit' class='btn btn-link text-info p-0 pl-2'
+                                        data-what='fragment'>{% trans 'Duplicate' %}</button>
+                                </div>
+                            </form>
+                            {% endif %}
+
+                            <div class="unlock-options">
+                                <button type='button' name='unlock'  class='dropdown-toggle btn btn-info'>Unlock</button>
+                                <div class="unlock-duration">
+                                    <button type='submit' name='days' value='1' class='dropdown-item'>for 1 day</button>
+                                    <button type='submit' name='days' value='2' class='dropdown-item'>for 2 days</button>
+                                    <button type='submit' name='days' value='5' class='dropdown-item'>for 5 days</button>
+                                    <button type='submit' name='days' value='7' class='dropdown-item'>for a week</button>
+                                    <button type='submit' name='lock' class='dropdown-item'>until I unlock</button>
+                                </div>
+                            </div>
                         </div>
                     </div>
                     {% endif %}

--- a/src/rard/templates/research/partials/render_locked_info.html
+++ b/src/rard/templates/research/partials/render_locked_info.html
@@ -75,8 +75,8 @@
                                 <button type='submit' class='btn btn-link text-info'
                                     data-what='testimonium'>{% trans 'Duplicate' %}</button>
                             </form>
-
-                        {% endif %} {% endcomment %}
+                        {% endcomment %}
+                        {% endif %}
 
                         <hr class="m-1">
 

--- a/src/rard/templates/research/partials/render_locked_info.html
+++ b/src/rard/templates/research/partials/render_locked_info.html
@@ -29,15 +29,14 @@
 
                         <div class="dropdown-menu text-center p-2" aria-labelledby="dropdownMenuLink">
 
-                            {% if object.is_unlinked %}
-                                <form novalidate class='form-group' action='{% url "fragment:convert_to_anonymous" fragment.pk %}' method='POST'>
-                                    {% csrf_token %}
-                                    <button type='submit' class='btn btn-link text-danger text-nowrap confirm-convert'
-                                        data-what='fragment'>{% trans 'Make anonymous' %}</button>
-                                </form>
-                            {% endif %}
+
                             {% if is_anonymousfragment %}
-                                <form novalidate class='form-group' action='{% url "anonymous_fragment:convert_to_fragment" object.pk %}' method='POST'>
+                            <form novalidate  class='form-group mb-0' action='{% url "anonymous_fragment:delete" object.pk %}' method='POST'>
+                                {% csrf_token %}
+                                    <button type='submit' class='btn btn-link text-danger {% if object.mentioned_in.all %}confirm-delete-mentions {% else %} confirm-delete {% endif %}'
+                                        data-what='anonymous fragment'>{% trans 'Delete' %}</button>
+                            </form>
+                                <form novalidate class='form-group mb-0' action='{% url "anonymous_fragment:convert_to_fragment" object.pk %}' method='POST'>
                                     {% csrf_token %}
                                     <button
                                     type='submit'
@@ -53,13 +52,32 @@
                                     <button type='submit' class='btn btn-link text-info'
                                         data-what='anonymous fragment'>{% trans 'Duplicate' %}</button>
                                 </form>
-                            {% endif %}
-                            {% if is_fragment %}
+                            {% elif is_fragment %}
+                            <form novalidate  class='form-group mb-0' action='{% url "fragment:delete" object.pk %}' method='POST'>
+                                {% csrf_token %}
+                                <button type='submit' class='btn btn-link text-danger {% if object.mentioned_in.all %}confirm-delete-mentions {% else %} confirm-delete {% endif %}'
+                                    data-what=' fragment'>{% trans 'Delete' %}</button>
+                            </form>
+                                {% if object.is_unlinked %}
+                                <form novalidate class='form-group mb-0' action='{% url "fragment:convert_to_anonymous" fragment.pk %}' method='POST'>
+                                    {% csrf_token %}
+                                    <button type='submit' class='btn btn-link text-danger text-nowrap confirm-convert'
+                                        data-what='fragment'>{% trans 'Make anonymous' %}</button>
+                                </form>
+                                {% endif %}
                                 <form novalidate class='form-group mb-0' action='{% url "fragment:duplicate" object.pk %}' method='POST'>
                                     {% csrf_token %}
                                     <button type='submit' class='btn btn-link text-info'
                                         data-what='fragment'>{% trans 'Duplicate' %}</button>
                                 </form>
+                            {% else %}
+                            <form novalidate class='form-group'  action='{% if is_testimonium %}{% url "testimonium:delete" testimonium.pk %} {% elif is_work %}{% url "work:delete" work.pk %} {% elif is_antiquarian %}{% url "antiquarian:delete" antiquarian.pk %}
+                            {% endif %}'
+                             method='POST'>
+                                {% csrf_token %}
+                                <button type='submit' class='btn btn-link text-danger {% if object.mentioned_in.all %}confirm-delete-mentions {% else %} confirm-delete {% endif %}'
+                                    data-what='{{is_testimonium}}{{is_work}}{{is_antiquarian}}'>{% trans 'Delete' %}</button>
+                            </form>
                             {% endif %}
                             <hr class="m-1">
                             <div class="unlock-options">

--- a/src/rard/templates/research/partials/render_locked_info.html
+++ b/src/rard/templates/research/partials/render_locked_info.html
@@ -29,29 +29,28 @@
 
                         <div class="dropdown-menu text-center p-2" aria-labelledby="dropdownMenuLink">
 
-
                             {% if is_anonymousfragment %}
                             <form novalidate  class='form-group mb-0' action='{% url "anonymous_fragment:delete" object.pk %}' method='POST'>
                                 {% csrf_token %}
-                                    <button type='submit' class='btn btn-link text-danger {% if object.mentioned_in.all %}confirm-delete-mentions {% else %} confirm-delete {% endif %}'
-                                        data-what='anonymous fragment'>{% trans 'Delete' %}</button>
+                                <button type='submit' class='btn btn-link text-danger {% if object.mentioned_in.all %}confirm-delete-mentions {% else %} confirm-delete {% endif %}'
+                                    data-what='anonymous fragment'>{% trans 'Delete' %}</button>
                             </form>
-                                <form novalidate class='form-group mb-0' action='{% url "anonymous_fragment:convert_to_fragment" object.pk %}' method='POST'>
-                                    {% csrf_token %}
-                                    <button
-                                    type='submit'
-                                    class='
-                                    {% if object.get_all_links %}has-links{% endif %}
-                                    btn btn-link text-danger confirm-convert p-1 text-nowrap
-                                    '
-                                    data-what='anonymous fragment'
-                                    >{% trans 'Make non-anonymous' %}</button>
-                                </form>
-                                <form novalidate class='form-group mb-0' action='{% url "anonymous_fragment:duplicate" object.pk %}' method='POST'>
-                                    {% csrf_token %}
-                                    <button type='submit' class='btn btn-link text-info'
-                                        data-what='anonymous fragment'>{% trans 'Duplicate' %}</button>
-                                </form>
+                            <form novalidate class='form-group mb-0' action='{% url "anonymous_fragment:convert_to_fragment" object.pk %}' method='POST'>
+                                {% csrf_token %}
+                                <button
+                                type='submit'
+                                class='
+                                {% if object.get_all_links %}has-links{% endif %}
+                                btn btn-link text-danger confirm-convert p-1 text-nowrap
+                                '
+                                data-what='anonymous fragment'
+                                >{% trans 'Make non-anonymous' %}</button>
+                            </form>
+                            <form novalidate class='form-group mb-0' action='{% url "anonymous_fragment:duplicate" object.pk %}' method='POST'>
+                                {% csrf_token %}
+                                <button type='submit' class='btn btn-link text-info'
+                                    data-what='anonymous fragment'>{% trans 'Duplicate' %}</button>
+                            </form>
                             {% elif is_fragment %}
                             <form novalidate  class='form-group mb-0' action='{% url "fragment:delete" object.pk %}' method='POST'>
                                 {% csrf_token %}
@@ -65,11 +64,11 @@
                                         data-what='fragment'>{% trans 'Make anonymous' %}</button>
                                 </form>
                                 {% endif %}
-                                <form novalidate class='form-group mb-0' action='{% url "fragment:duplicate" object.pk %}' method='POST'>
-                                    {% csrf_token %}
-                                    <button type='submit' class='btn btn-link text-info'
-                                        data-what='fragment'>{% trans 'Duplicate' %}</button>
-                                </form>
+                            <form novalidate class='form-group mb-0' action='{% url "fragment:duplicate" object.pk %}' method='POST'>
+                                {% csrf_token %}
+                                <button type='submit' class='btn btn-link text-info'
+                                    data-what='fragment'>{% trans 'Duplicate' %}</button>
+                            </form>
                             {% else %}
                             <form novalidate class='form-group'  action='{% if is_testimonium %}{% url "testimonium:delete" testimonium.pk %} {% elif is_work %}{% url "work:delete" work.pk %} {% elif is_antiquarian %}{% url "antiquarian:delete" antiquarian.pk %}
                             {% endif %}'
@@ -79,6 +78,7 @@
                                     data-what='{{is_testimonium}}{{is_work}}{{is_antiquarian}}'>{% trans 'Delete' %}</button>
                             </form>
                             {% endif %}
+
                             <hr class="m-1">
                             <div class="unlock-options">
                                 <button type='button' name='unlock'  class='dropdown-toggle btn btn-link text-primary w-100 p-1 m-1'>Unlock</button>
@@ -86,7 +86,7 @@
                                     <button type='submit' name='days' value='1' class='dropdown-item'>for 1 day</button>
                                     <button type='submit' name='days' value='2' class='dropdown-item'>for 2 days</button>
                                     <button type='submit' name='days' value='7' class='dropdown-item'>for a week</button>
-                                    <button type='submit' name='lock' class='dropdown-item'>until I unlock</button>
+                                    <button type='submit' name='lock' class='dropdown-item text-danger'>until I unlock</button>
                                 </div>
                             </div>
                         </div>

--- a/src/rard/templates/research/partials/render_locked_info.html
+++ b/src/rard/templates/research/partials/render_locked_info.html
@@ -2,7 +2,7 @@
 
 {% load humanize object_lock i18n %}
 
-    <div class='d-flex align-items-center mb-2'>
+    <div class='align-items-center mb-2'>
         <div class='mr-3'>
 
             {% include 'research/partials/render_locked_icons.html' %}
@@ -12,6 +12,7 @@
             <form novalidate enctype="multipart/form-data" autocomplete='off' action='{{ request.path }}' class="form"
                 method='POST'>
                 {% csrf_token %}
+                {% if object.locked_by == request.user %}
                 <div class="dropdown show">
                     <a class="btn btn-primary btn-sm dropdown-toggle" name='lock' href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                         Actions
@@ -59,34 +60,33 @@
                         </form>
 
                         {% endif %}
+                        <hr>
+                    <button type='submit' class='btn btn-link text-primary btn-sm' name='unlock'>Finish&nbsp;Editing</button>
+                {% else %}
+                    {% if object.is_locked %}
+                        <button type='submit' class='btn btn-warning btn-sm' name='request'>Request Item</button>
+                        {% if request.user.can_break_locks %}
+                            <button title='You can break this lock'  type='submit' class='btn btn-danger btn-sm' name='break'><i class='fa fa-unlock'></i> Unlock</button>
+                        {% endif %}
+                    {% elif not object.is_locked %}
 
-                        <hr class="m-1">
+                    <div class="dropdown show">
+                        <a class="btn btn-primary btn-sm dropdown-toggle" name='lock' href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            Edit
+                        </a>
 
-                        {% if object.locked_by == request.user %}
-                        <button type='submit' class='btn btn-link text-primary' name='unlock'>Finish Editing</button>
-
-                        {% else %}
-                            {% if object.is_locked %}
-                            <button type='submit' class='btn btn-link text-warning' name='request'>Request Item</button>
-                                {% if request.user.can_break_locks %}
-                                    <button title='You can break this lock'  type='submit' class='btn btn-link text-danger' name='break'><i class='fa fa-unlock'></i> Unlock</button>
-                                {% endif %}
-
-                            {% elif not object.is_locked %}
-                            <div class="lock-options">
-                                <button type='button' name='lock'  class='dropdown-toggle btn btn-link text-primary w-100 p-1 m-1'>Edit</button>
-                                <div class="lock-duration form-group">
+                        <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
+                                <div class="lock-duration">
                                     <button type='submit' name='days' value='1' class='dropdown-item'>for 1 day</button>
                                     <button type='submit' name='days' value='2' class='dropdown-item'>for 2 days</button>
                                     <button type='submit' name='days' value='7' class='dropdown-item'>for a week</button>
-                                    <button type='submit' name='lock' class='dropdown-item text-danger'>until I unlock</button>
+                                    <button type='submit' name='lock' class='dropdown-item'>until I unlock</button>
                                 </div>
-                            </div>
-                            {% endif %}
-                        {% endif %}
+                        </div>
                     </div>
-                </div>
+                    {% endif %}
 
+                {% endif %}
             </form>
         </div>
     </div>

--- a/src/rard/templates/research/partials/render_locked_info.html
+++ b/src/rard/templates/research/partials/render_locked_info.html
@@ -53,13 +53,30 @@
                                     data-what='fragment'>{% trans 'Make anonymous' %}</button>
                             </form>
                             {% endif %}
-                        <form novalidate class='form-group mb-0' action='{% url "fragment:duplicate" object.pk %}' method='POST'>
-                            {% csrf_token %}
-                            <button type='submit' class='btn btn-link text-info'
-                                data-what='fragment'>{% trans 'Duplicate' %}</button>
-                        </form>
+                            <form novalidate class='form-group mb-0' action='{% url "fragment:duplicate" object.pk %}' method='POST'>
+                                {% csrf_token %}
+                                <button type='submit' class='btn btn-link text-info'
+                                    data-what='fragment'>{% trans 'Duplicate' %}</button>
+                            </form>
+                        {% comment %} {% elif is_testimonium %}
+                            <form novalidate class='form-group mb-0' action='{% url "testimonium:convert_to_fragment" object.pk %}' method='POST'>
+                                {% csrf_token %}
+                                <button
+                                type='submit'
+                                class='
+                                {% if object.get_all_links %}has-links{% endif %}
+                                btn btn-link text-danger confirm-convert p-1 text-nowrap
+                                '
+                                data-what='testimonium'
+                                >{% trans 'Make fragment' %}</button>
+                            </form>
+                            <form novalidate class='form-group mb-0' action='{% url "testimonium:duplicate" object.pk %}' method='POST'>
+                                {% csrf_token %}
+                                <button type='submit' class='btn btn-link text-info'
+                                    data-what='testimonium'>{% trans 'Duplicate' %}</button>
+                            </form>
 
-                        {% endif %}
+                        {% endif %} {% endcomment %}
 
                         <hr class="m-1">
 

--- a/src/rard/templates/research/testimonium_detail.html
+++ b/src/rard/templates/research/testimonium_detail.html
@@ -13,21 +13,8 @@
 {% block action %}
     {% with request.user|has_lock:object as has_object_lock %}
 
-        {% include 'research/partials/render_locked_info.html' %}
+        {% include 'research/partials/render_locked_info.html' with is_testimonium="testimonium" %}
 
-        <div class='d-flex justify-content-end'>
-        {% if has_object_lock %}
-            {% if perms.research.delete_testimonium %}
-            <form novalidate class='form-inline' action='{% url "testimonium:delete" testimonium.pk %}' method='POST'>
-                {% csrf_token %}
-                <div class='form-group'>
-                    <button type='submit' class='btn btn-link text-danger {% if object.mentioned_in.all %}confirm-delete-mentions {% else %} confirm-delete {% endif %} p-0 ml-2'
-                        data-what='testimonium'>{% trans 'Delete' %}</button>
-                </div>
-            </form>
-            {% endif %}
-        {% endif %}
-        </div>
     {% endwith %}
 {% endblock %}
 
@@ -39,13 +26,6 @@
         <div class='d-flex justify-content-between mb-3'>
             <div>
                 <h5>{% trans 'Details' %}</h5>
-            </div>
-            <div>
-                {% comment %}
-                {% if perms.research.change_testimonium and has_object_lock %}
-                <a href='{% url "testimonium:update" object.pk %}'>{% trans 'Edit' %}</a>
-                {% endif %}
-                {% endcomment %}
             </div>
         </div>
 

--- a/src/rard/templates/research/work_detail.html
+++ b/src/rard/templates/research/work_detail.html
@@ -20,21 +20,8 @@
 
     {% with request.user|has_lock:object as has_object_lock %}
 
-        {% include 'research/partials/render_locked_info.html' %}
+        {% include 'research/partials/render_locked_info.html' with is_work="work" %}
 
-        <div class='d-flex justify-content-end'>
-        {% if has_object_lock %}
-            {% if perms.research.delete_work %}
-                <form novalidate class='form-inline' action='{% url "work:delete" work.pk %}' method='POST'>
-                    {% csrf_token %}
-                    <div class='form-group'>
-                        <button type='submit' class='btn btn-link text-danger confirm-delete p-0 ml-2'
-                            data-what='work'>{% trans 'Delete' %}</button>
-                    </div>
-                </form>
-            {% endif %}
-        {% endif %}
-        </div>
     {% endwith %}
 {% endblock %}
 


### PR DESCRIPTION
closes #434 and #447
---
The `Edit` menu has been rejigged to better display options and complete actions without having to require an editing lock. This helps bring more consistency and reduces the code volume.

- Deletion, conversion and duplication are available where relevant without needing a lock and are available when there is a lock
- locking editing is available from the same menu as a dropdown 

Below are screengrabs:

(unlinked) fragment without editing lock:
<img width="259" alt="image" src="https://github.com/UCL/frrant/assets/72266023/bdc58824-e002-464a-bba2-cfc1f9269565">

when editing:
<img width="237" alt="image" src="https://github.com/UCL/frrant/assets/72266023/44d25460-7ede-4b29-92c4-4171caeaf943">


testimonia, works and antiquarians when editing:
<img width="211" alt="image" src="https://github.com/UCL/frrant/assets/72266023/b5f44c69-ad05-4ce8-9a91-e882e90b1de5">

anonymous without editing lock:
<img width="280" alt="image" src="https://github.com/UCL/frrant/assets/72266023/1ee743bf-97a6-41e6-807b-ba4a68595d69">



