### PR TITLE
fixing password reset url on preprod

### DIFF
--- a/src/compose/development/django/site.json
+++ b/src/compose/development/django/site.json
@@ -1,10 +1,10 @@
 [
-{
+  {
     "model": "sites.site",
     "pk": 1,
     "fields": {
-        "domain": "frra-app01p.ad.ucl.ac.uk",
-        "name": "Republican Antiquarians Research Database"
+      "domain": "ucl.ac.uk",
+      "name": "Republican Antiquarians Research Database"
     }
-}
+  }
 ]


### PR DESCRIPTION
closes #457 
---
preprod was using the server name as the domain so the reset link sent didn't work, have set it to be ucl.ac.uk (without www since that version gets loaded in and would be a duplicate), this then works