### PR TITLE
Amending translation public view

### DIFF
--- a/src/rard/templates/research/anonymousfragment_detail.html
+++ b/src/rard/templates/research/anonymousfragment_detail.html
@@ -152,9 +152,17 @@
         {% include 'research/partials/section/original_text_details.html' with show_concordances=True original_text=original_text can_edit=perms.research.change_fragment has_object_lock=has_object_lock %}
 
         <div class='mt-3'>
-        {% for translation in original_text.translation_set.all %}
-            {% include 'research/partials/translation_preview.html' with translation=translation can_edit=perms.research.change_fragment has_object_lock=has_object_lock %}
-        {% endfor %}
+        {% if perms.research.change_fragment and has_object_lock %}
+            {% for translation in original_text.translation_set.all %}
+                {% include 'research/partials/translation_preview.html' with translation=translation can_edit=perms.research.change_fragment has_object_lock=has_object_lock %}
+            {% endfor %}
+        {% else %}
+            {% for translation in original_text.translation_set.all %}
+                {% if translation.approved %}
+                    {% include 'research/partials/translation_preview.html' with translation=translation can_edit=perms.research.change_fragment has_object_lock=has_object_lock %}
+                {% endif %}
+            {% endfor %}
+        {% endif %}
         </div>
 
     </section>

--- a/src/rard/templates/research/fragment_detail.html
+++ b/src/rard/templates/research/fragment_detail.html
@@ -147,9 +147,17 @@
         {% include 'research/partials/section/original_text_details.html' with show_concordances=True original_text=original_text can_edit=perms.research.change_fragment has_object_lock=has_object_lock %}
 
         <div class='mt-3'>
-        {% for translation in original_text.translation_set.all %}
-            {% include 'research/partials/translation_preview.html' with translation=translation can_edit=perms.research.change_fragment has_object_lock=has_object_lock %}
-        {% endfor %}
+        {% if perms.research.change_fragment and has_object_lock %}
+            {% for translation in original_text.translation_set.all %}
+                {% include 'research/partials/translation_preview.html' with translation=translation can_edit=perms.research.change_fragment has_object_lock=has_object_lock %}
+            {% endfor %}
+        {% else %}
+            {% for translation in original_text.translation_set.all %}
+                {% if translation.approved %}
+                    {% include 'research/partials/translation_preview.html' with translation=translation can_edit=perms.research.change_fragment has_object_lock=has_object_lock %}
+                {% endif %}
+            {% endfor %}
+        {% endif %}
         </div>
 
     </section>

--- a/src/rard/templates/research/partials/translation_preview.html
+++ b/src/rard/templates/research/partials/translation_preview.html
@@ -2,14 +2,14 @@
 
 {% load i18n humanize %}
 
-<div class="card mb-3 bg-light  {% if translation.approved %}border-success{% endif %}">
+<div class="card mb-3 bg-light  {% if translation.approved and has_object_lock %}border-success{% endif %}">
     <div class="card-body">
         <div class='card-text'>
             <div class='d-flex justify-content-between'>
                 <div class='alphabetum'>
                     {{ translation.translated_text|safe }}
                 </div>
-                {% if translation.approved %}
+                {% if translation.approved and has_object_lock %}
                 <div class='text-success mt-n3'>
                     <small>{% trans 'Approved' %}</small>
                 </div>

--- a/src/rard/templates/research/testimonium_detail.html
+++ b/src/rard/templates/research/testimonium_detail.html
@@ -117,9 +117,17 @@
 
 
         <div class='mt-3'>
-        {% for translation in original_text.translation_set.all %}
-            {% include 'research/partials/translation_preview.html' with translation=translation can_edit=perms.research.change_testimonium has_object_lock=has_object_lock %}
-        {% endfor %}
+            {% if perms.research.change_testimonium and has_object_lock %}
+            {% for translation in original_text.translation_set.all %}
+                {% include 'research/partials/translation_preview.html' with translation=translation can_edit=perms.research.change_testimonium has_object_lock=has_object_lock %}
+            {% endfor %}
+        {% else %}
+            {% for translation in original_text.translation_set.all %}
+                {% if translation.approved %}
+                    {% include 'research/partials/translation_preview.html' with translation=translation can_edit=perms.research.change_testimonium has_object_lock=has_object_lock %}
+                {% endif %}
+            {% endfor %}
+        {% endif %}
         </div>
 
 


### PR DESCRIPTION
closes #37
---
Only approved translations shown to the general public (without object lock), this is without the green border or "approved" note (irrelevant if only one seen)
This can probably be merged later on