### PR TITLE
fixing delete not working in new menu format

### DIFF
--- a/src/rard/templates/research/partials/render_locked_info.html
+++ b/src/rard/templates/research/partials/render_locked_info.html
@@ -9,8 +9,6 @@
 
         </div>
         <div>
-            <form novalidate enctype="multipart/form-data" autocomplete='off' action='{{ request.path }}' class="form"
-                method='POST'>
                 {% csrf_token %}
                 {% if object.locked_by == request.user %}
                 <div class="dropdown show">
@@ -19,8 +17,7 @@
                     </a>
 
                     <div class="dropdown-menu text-center p-2" aria-labelledby="dropdownMenuLink">
-                        <form novalidate class='form-group'  action='{% if is_testimonium %}{% url "testimonium:delete" testimonium.pk %} {% elif is_work %}{% url "work:delete" work.pk %} {% elif is_antiquarian %}{% url "antiquarian:delete" antiquarian.pk %}{% elif is_anonymousfragment %}{% url "anonymous_fragment:delete" object.pk %}{% elif is_fragment %}{% url "fragment:delete" object.pk %}
-                        {% endif %}'
+                        <form novalidate class='form-group mb-0'  action='{% if is_testimonium %}{% url "testimonium:delete" object.pk %} {% elif is_work %}{% url "work:delete" object.pk %} {% elif is_antiquarian %}{% url "antiquarian:delete" object.pk %}{% elif is_anonymousfragment %}{% url "anonymous_fragment:delete" object.pk %}{% elif is_fragment %}{% url "fragment:delete" object.pk %}{% endif %}'
                             method='POST'>
                             {% csrf_token %}
                             <button type='submit' class='btn btn-link text-danger {% if object.mentioned_in.all %}confirm-delete-mentions {% else %} confirm-delete {% endif %}'
@@ -88,6 +85,9 @@
                     </div>
                 </div>
                 {% else %}
+                <form novalidate enctype="multipart/form-data" autocomplete='off' action='{{ request.path }}' class="form"
+                method='POST'>
+                {% csrf_token %}
                     {% if object.is_locked %}
                         <button type='submit' class='btn btn-warning btn-sm' name='request'>Request Item</button>
                         {% if request.user.can_break_locks %}
@@ -108,9 +108,8 @@
                         </div>
                     </div>
                     {% endif %}
-
+                    </form>
                 {% endif %}
-            </form>
         </div>
     </div>
     {% with user_lock_request=request.user|lock_request:object %}


### PR DESCRIPTION
closes #434 
---
#442 automatically merged when #456 did so have done this fix separately



The delete form wasn't rendering  because of the nesting within the bigger form so I've split the menu into 2 versions, one for when it's locked, and one for when it's unlocked, with the relevant forms