### PR TITLE
Hotfix/definite fields

### DIFF
--- a/src/rard/research/forms.py
+++ b/src/rard/research/forms.py
@@ -925,11 +925,11 @@ class BaseLinkWorkForm(forms.ModelForm):
             else:
                 # Get everything from initial
                 initial_data = kwargs["initial"]
-                antiquarian = initial_data["antiquarian"]
+                antiquarian = initial_data.get("antiquarian")
                 definite_antiquarian = initial_data.get("definite_antiquarian", False)
-                work = initial_data["work"]
+                work = initial_data.get("work")
                 definite_work = initial_data.get("definite_work", False)
-                book = kwargs["initial"]["book"]
+                book = initial_data.get("book")
 
         if antiquarian:
             self.fields["antiquarian"].initial = antiquarian

--- a/src/rard/research/forms.py
+++ b/src/rard/research/forms.py
@@ -923,8 +923,8 @@ class BaseLinkWorkForm(forms.ModelForm):
                     book = Book.objects.get(pk=book_id)
                 antiquarian = Antiquarian.objects.get(pk=kwargs["data"]["antiquarian"])
             else:
-                initial_data = kwargs["initial"]
                 # Get everything from initial
+                initial_data = kwargs["initial"]
                 antiquarian = initial_data["antiquarian"]
                 definite_antiquarian = initial_data.get("definite_antiquarian", False)
                 work = initial_data["work"]

--- a/src/rard/research/forms.py
+++ b/src/rard/research/forms.py
@@ -915,7 +915,6 @@ class BaseLinkWorkForm(forms.ModelForm):
             self.fields["work"].empty_label = None
             self.fields["book"].empty_label = None
 
-            print(args, kwargs)
             if "data" in kwargs:
                 # Get Work and Book from post data
                 if work_id := kwargs["data"]["work"]:
@@ -924,11 +923,12 @@ class BaseLinkWorkForm(forms.ModelForm):
                     book = Book.objects.get(pk=book_id)
                 antiquarian = Antiquarian.objects.get(pk=kwargs["data"]["antiquarian"])
             else:
+                initial_data = kwargs["initial"]
                 # Get everything from initial
-                antiquarian = kwargs["initial"]["antiquarian"]
-                definite_antiquarian = kwargs["initial"]["definite_antiquarian"]
-                work = kwargs["initial"]["work"]
-                definite_work = kwargs["initial"]["definite_work"]
+                antiquarian = initial_data["antiquarian"]
+                definite_antiquarian = initial_data.get("definite_antiquarian", False)
+                work = initial_data["work"]
+                definite_work = initial_data.get("definite_work", False)
                 book = kwargs["initial"]["book"]
 
         if antiquarian:

--- a/src/rard/research/forms.py
+++ b/src/rard/research/forms.py
@@ -26,6 +26,7 @@ from rard.research.models.base import (
     FragmentLink,
     TestimoniumLink,
 )
+from rard.research.models.text_object_field import TextObjectField
 
 
 def _validate_reference_order(ro):
@@ -365,6 +366,9 @@ class WorkForm(forms.ModelForm):
         if commit:
             instance.save_without_historical_record()
             # introduction will have been created at this point
+            if not instance.introduction:
+                instance.introduction = TextObjectField().objects.create(content="")
+                instance.save()
             instance.introduction.content = self.cleaned_data["introduction_text"]
             instance.introduction.save_without_historical_record()
         return instance
@@ -911,6 +915,7 @@ class BaseLinkWorkForm(forms.ModelForm):
             self.fields["work"].empty_label = None
             self.fields["book"].empty_label = None
 
+            print(args, kwargs)
             if "data" in kwargs:
                 # Get Work and Book from post data
                 if work_id := kwargs["data"]["work"]:


### PR DESCRIPTION
There's been a slew of errors arising from trying to update links, eg:
```
Internal Server Error: /history/frrant/testimonium/update-link/343

KeyError at /history/frrant/testimonium/update-link/343
'definite_antiquarian'
```

This seems to be because when initialising the form, there's no data for `definite_antiquarian`. As such, I've set the definite values to be false if they cannot be found. The form can then initialise and the fields updated as necessary.

Similar issue with saving the work introduction form as sometimes there isn't an attached TOF instance