### PR TITLE
Feature/new concordances tc fixes

### DIFF
--- a/src/rard/research/forms.py
+++ b/src/rard/research/forms.py
@@ -1248,12 +1248,19 @@ class ConcordanceModelUpdateForm(forms.ModelForm):
         model = ConcordanceModel
         fields = [
             "identifier",
+            "new_identifier",
             "display_order",
             "content_type",
             "reference",
             "concordance_order",
         ]
         labels = {"identifier": "Part Identifier"}
+
+    new_identifier = forms.CharField(
+        label="New Part Identifier",
+        required=False,
+        help_text="You do not need to include the edition name, only the relevant part identifier without brackets[ ]",
+    )
 
     display_order = forms.CharField(
         label="optional ordering",
@@ -1272,7 +1279,7 @@ class ConcordanceModelUpdateForm(forms.ModelForm):
             qs = PartIdentifier.objects.filter(
                 edition=self.instance.identifier.edition
             ).order_by("edition")
-            self.fields["identifier"].queryset = qs
+            self.fields["identifier"].queryset = qs.filter(is_template=False)
 
 
 class ConcordanceModelSearchForm(forms.Form):

--- a/src/rard/research/forms.py
+++ b/src/rard/research/forms.py
@@ -1214,10 +1214,13 @@ class ConcordanceModelCreateForm(forms.ModelForm):
         self.fields["reference"].help_text = "Eg. 130c"
         self.fields["concordance_order"].help_text = "Eg. 130.3"
 
-        new_pi_help = (
-            f"Format: {part_format}. You do not need to include the edition name, "
-            + "only the relevant part identifier without brackets[ ]"
-        )
+        if part_format.value == "[none]":
+            new_pi_help = "Format is [none]; this edition has no parts."
+        else:
+            new_pi_help = (
+                f"Format: {part_format}. You do not need to include the edition name, "
+                + "only the relevant part identifier without brackets[ ]"
+            )
         self.fields["new_identifier"].help_text = new_pi_help
 
         # baseline for identifier field

--- a/src/rard/research/models/concordance.py
+++ b/src/rard/research/models/concordance.py
@@ -49,6 +49,11 @@ class Edition(HistoryModelMixin, BaseModel):
         max_length=200, blank=True, null=True
     )  # need to add this to master bib
 
+    def get_part_format(self):
+        return (
+            PartIdentifier.objects.filter(edition=self).filter(is_template=True).first()
+        )
+
 
 class ConcordanceModel(HistoryModelMixin, BaseModel):
     def __str__(self):

--- a/src/rard/research/models/concordance.py
+++ b/src/rard/research/models/concordance.py
@@ -1,16 +1,32 @@
+import re
+
 from django.db import models
-from django.db.models import Case, IntegerField, When
+from django.db.models import Case, IntegerField, Value, When
 
 from rard.research.models.mixins import HistoryModelMixin
 from rard.utils.basemodel import BaseModel
 
 
+class PartIdentifierManager(models.Manager):
+    def get_queryset(self):
+        return (
+            super()
+            .get_queryset()
+            .annotate(
+                is_template=Case(
+                    When(value__regex=r".*\[.*\].*", then=Value(True)),
+                    default=Value(False),
+                )
+            )
+            .order_by("-is_template", "edition__name", "value")
+        )
+
+
 class PartIdentifier(HistoryModelMixin, BaseModel):
-    class Meta:
-        ordering = ["edition__name", "value"]
+    objects = PartIdentifierManager()
 
     def __str__(self):
-        if self.is_template:
+        if re.search(self.value, r".*\[.*\].*"):
             return f"format for {self.edition.name}: {self.value}"
         else:
             return f"{self.edition.name}: {self.value}"
@@ -18,10 +34,6 @@ class PartIdentifier(HistoryModelMixin, BaseModel):
     edition = models.ForeignKey("Edition", on_delete=models.CASCADE)
     value = models.CharField(max_length=250, blank=False)
     display_order = models.CharField(max_length=30, blank=True)
-
-    @property
-    def is_template(self):
-        return "[" in self.value and "]" in self.value
 
 
 class Edition(HistoryModelMixin, BaseModel):

--- a/src/rard/research/views/concordance.py
+++ b/src/rard/research/views/concordance.py
@@ -206,7 +206,7 @@ class ConcordanceEditionView(
         edition_form = EditionForm(request.POST)
         if edition_form.is_valid():
             if new_edition:
-                if part_format is None:
+                if not part_format:
                     part_format = "[none]"
 
                 if not (part_format.startswith("[") and part_format.endswith("]")):
@@ -389,6 +389,8 @@ class ConcordanceUpdateView(
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
+        edition = self.object.identifier.edition
+        part_format = edition.get_part_format()
         context.update(
             {
                 "original_text": self.object.original_text,
@@ -397,6 +399,8 @@ class ConcordanceUpdateView(
                 "request_action": reverse(
                     "concordance:update", kwargs={"pk": self.object.pk}
                 ),
+                "part_format": part_format,
+                "edition": edition,
             }
         )
         return context

--- a/src/rard/research/views/concordance.py
+++ b/src/rard/research/views/concordance.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
+from django.db import DatabaseError
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
@@ -57,10 +58,16 @@ def fetch_parts(request):
 
 
 def get_part_format(edition):
-    first_part = PartIdentifier.objects.filter(edition=edition).first()
-    if first_part and first_part.is_template:
-        part_format = first_part
-        return part_format
+    """Get the first part identifier that is a template for the given edition.
+    If no template exists, raise a DatabaseError since all Editions should have
+    a template."""
+    first_part = (
+        PartIdentifier.objects.filter(edition=edition).filter(is_template=True).first()
+    )
+    if first_part:
+        return first_part
+    else:
+        raise DatabaseError(f"No template part identifier exists for edition {edition}")
 
 
 def create_edition_bib_item(pk):

--- a/src/rard/static/css/project.css
+++ b/src/rard/static/css/project.css
@@ -527,7 +527,7 @@ section.footnotes {
 }
 
 .form-section {
-  margin-bottom: 40px;
+  margin-bottom: 3rem;
 }
 
 /* concordance search */

--- a/src/rard/static/css/project.css
+++ b/src/rard/static/css/project.css
@@ -490,7 +490,7 @@ section.footnotes {
 }
 .concordance-form__area {
   min-height: 30vh;
-  margin-inline: 2vw;
+  /* margin-inline: 2vw; */
 
   [disable-selection="true"] {
     color: gray;
@@ -524,6 +524,10 @@ section.footnotes {
     bottom: 2.5rem;
     left: 8rem;
   }
+}
+
+.form-section {
+  margin-bottom: 40px;
 }
 
 /* concordance search */

--- a/src/rard/templates/research/concordancemodel_form.html
+++ b/src/rard/templates/research/concordancemodel_form.html
@@ -25,11 +25,12 @@
 {% if original_text.concordances.count != 0 %}
 <div>
     This original text has some existing concordances in the old format:
-    <div>
+    <ul class="list-inline">
     {% for c in original_text.concordances.all %}
-    {{c}} |
+        <li class="list-inline-item">{{c}}</li>
+        <li class="list-inline-item">{% if not forloop.last %}|{% endif %}</li>
     {% endfor %}
-    </div>
+    </ul>
 </div>
 <br>
 {% endif %}

--- a/src/rard/templates/research/concordancemodel_form.html
+++ b/src/rard/templates/research/concordancemodel_form.html
@@ -20,7 +20,7 @@
     <label>For original text:</label>
 
         <div>
-            {% include 'research/partials/original_text_preview.html' with original_text=original_text %}
+            {% include 'research/partials/original_text_preview.html' with original_text=original_text hide_last_modified=True %}
         </div>
 {% if original_text.concordances.count != 0 %}
 <div>

--- a/src/rard/templates/research/partials/concordance_edition_section.html
+++ b/src/rard/templates/research/partials/concordance_edition_section.html
@@ -5,7 +5,7 @@
 
     <div class="d-flex flex-column justify-content-between edition-select">
     {% bootstrap_field edition_form.edition %}
-    <h2 class="alphabetum btn-link new-edition-btn">Or create a new Edition >></h2>
+    <h2 class="btn-link new-edition-btn small">Or create a new Edition >></h2>
     </div>
 
     <div class="d-flex flex-column new-edition invisible justify-content-between">
@@ -17,7 +17,7 @@
             {% bootstrap_field edition_form.part_format %}
             <input type="hidden" name="original_text" value={{original_text.pk}}>
         </div>
-        <h2 class="alphabetum btn-link select-edition-btn">Or select Edition >></h2>
+        <h2 class="btn-link select-edition-btn small">Or select Edition >></h2>
     </div>
     <br>
     <script>

--- a/src/rard/templates/research/partials/concordance_form_section.html
+++ b/src/rard/templates/research/partials/concordance_form_section.html
@@ -1,32 +1,30 @@
 {% load i18n bootstrap4 %}
-<h1 class="alphabetum">{% if is_update %}Update{% else %}Add{% endif %} Concordance Details</h1>
 
 <form novalidate enctype="multipart/form-data" autocomplete='off' action='{{ request_action }}' class="form" method='POST'>
     {% csrf_token %}
     <input type="hidden" name="original_text" value={{original_text.pk}}>
-
-        <strong>Edition: {{edition}} {% if is_update %} {{object.identifier.edition}} {% endif %} </strong>
+    <div class="form-section">
+        <h2 class="alphabetum mt-2">{% trans 'Edition' %} </h2>
+        <p><strong>{{edition}}</strong></p>
         {% if not is_update %}
         <input type="hidden" name="edition" value={{edition.pk}}>
         {% endif %}
+    </div>
 
-        <h2 class="alphabetum mt-2">{% trans 'Identifier details' %} </h2>
+    <div class="form-section">
         <div class="identifier-select">
         {% bootstrap_field concordance_form.identifier %}
         {% if not is_update %}
-        <h2 class="alphabetum btn-link new-identifier-btn">Or create a new Part Identifier >></h2>
+        <p class="btn-link new-identifier-btn small">Or create a new Part Identifier >></p>
         {% endif %}
         </div>
 
         <div class="new-identifier invisible">
-        {% if part_format is not None %}
-        <p>{{part_format}}</p>
-        {% endif %}
             <div class="d-flex flex-row justify-content-around">
             {% bootstrap_field concordance_form.new_identifier %}
             {% bootstrap_field concordance_form.display_order %}
             </div>
-            <h2 class="alphabetum btn-link select-identifier-btn">Or select Part Identifier >></h2>
+            <h2 class="btn-link select-identifier-btn small">Or select Part Identifier >></h2>
         </div>
 
         <script>
@@ -50,12 +48,15 @@
     }
 
         </script>
-        <h2 class="alphabetum mt-2">{% trans 'Concordance details' %} </h2>
+
+    </div>
+    <div class="form-section">
         <div class="d-flex justify-content-between mt-3">
             {% bootstrap_field concordance_form.content_type %}
             {% bootstrap_field concordance_form.reference %}
             {% bootstrap_field concordance_form.concordance_order %}
         </div>
+    </div>
 
         <button type="submit" class="btn btn-primary ">
         {% if object %}

--- a/src/rard/templates/research/partials/concordance_form_section.html
+++ b/src/rard/templates/research/partials/concordance_form_section.html
@@ -19,6 +19,7 @@
         {% endif %}
         </div>
 
+        {% if not is_update %}
         <div class="new-identifier invisible">
             <div class="d-flex flex-row justify-content-around">
             {% bootstrap_field concordance_form.new_identifier %}
@@ -48,6 +49,7 @@
     }
 
         </script>
+        {% endif %}
 
     </div>
     <div class="form-section">

--- a/src/rard/templates/research/partials/concordance_form_section.html
+++ b/src/rard/templates/research/partials/concordance_form_section.html
@@ -13,15 +13,15 @@
 
     <div class="form-section">
         <div class="identifier-select">
-        {% bootstrap_field concordance_form.identifier %}
-        {% if not is_update %}
-        <p class="btn-link new-identifier-btn small">Or create a new Part Identifier >></p>
-        {% endif %}
+            {% bootstrap_field concordance_form.identifier %}
+            {% if not is_update %}
+            <p class="btn-link new-identifier-btn small">Or create a new Part Identifier >></p>
+            {% endif %}
         </div>
 
         {% if not is_update %}
         <div class="new-identifier invisible">
-            <div class="d-flex flex-row justify-content-around">
+            <div class="d-flex flex-row justify-content-between">
             {% bootstrap_field concordance_form.new_identifier %}
             {% bootstrap_field concordance_form.display_order %}
             </div>
@@ -32,21 +32,22 @@
             var newIdentifierArea = document.querySelector(".new-identifier");
             var identifierSelectArea = document.querySelector(".identifier-select");
 
+            // Identifier select input will be disabled if none exist yet so don't show it
             if(document.getElementById("id_identifier").disabled){
                 identifierSelectArea.classList.add("invisible");
                 newIdentifierArea.classList.remove("invisible");
                 document.querySelector(".select-identifier-btn").classList.add("invisible")
             }
 
-        // swap between the forms
-        document.querySelector(".new-identifier-btn").onclick = ()=>{
-            identifierSelectArea.classList.add("invisible");
-            newIdentifierArea.classList.remove("invisible");
-        };
-        document.querySelector(".select-identifier-btn").onclick = ()=>{
-            identifierSelectArea.classList.remove("invisible");
-            newIdentifierArea.classList.add("invisible");
-    }
+            // swap between the forms
+            document.querySelector(".new-identifier-btn").onclick = ()=>{
+                identifierSelectArea.classList.add("invisible");
+                newIdentifierArea.classList.remove("invisible");
+            };
+            document.querySelector(".select-identifier-btn").onclick = ()=>{
+                identifierSelectArea.classList.remove("invisible");
+                newIdentifierArea.classList.add("invisible");
+            };
 
         </script>
         {% endif %}

--- a/src/rard/templates/research/partials/original_text_preview.html
+++ b/src/rard/templates/research/partials/original_text_preview.html
@@ -1,6 +1,6 @@
 {# Assumes a context object named 'original_text' #}
 
-{% include 'research/partials/text_object_preview.html' with text_object=original_text %}
+{% include 'research/partials/text_object_preview.html' with text_object=original_text hide_last_modified=hide_last_modified %}
 
 {% comment %}
 <div class="card mt-3 mb-5 bg-light">


### PR DESCRIPTION
First of all fixes a bug caused by existing edition's PI templates not getting picked up. The solution uses a custom manager to include is_template as an annotation, which allows us to filter and order by is_template directly. It did mean I had to use a regex in the __str__ function though because you can't have a property and an annotation with the same name. I think the simplest solution would have been for is_template to have been a boolean field on the PartIdentifier model, but that'd involve another migration.

I've also made a few tweaks to styling and form layout - feel free to revert these or cherrypick the good bits.