### PR TITLE
Add proximity search

### DIFF
--- a/src/rard/research/tests/views/test_search.py
+++ b/src/rard/research/tests/views/test_search.py
@@ -444,6 +444,46 @@ class TestSearchView(TestCase):
         self.assertEqual(do_search(view.fragment_search, "again"), [f3])
         self.assertEqual(do_search(view.fragment_search, "again?"), [])
 
+    def test_proximity_search(self):
+        # Run a particular search and return a list of results
+        def do_search(search_function, keywords):
+            return list(search_function(SearchView.Term(keywords)))
+
+        cw = CitingWork.objects.create(title="citing_work")
+        f1 = Fragment.objects.create()
+        content1 = (
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit, "
+            "sed do eiusmod tempor incididunt ut labore et dolore magna"
+            "aliqua."
+        )
+        f1.original_texts.create(**{"citing_work": cw, "content": content1})
+
+        view = SearchView()
+
+        # Test exact number of intervening words
+        self.assertEqual(do_search(view.fragment_search, "Lorem ~4 consectetur"), [f1])
+        self.assertEqual(do_search(view.fragment_search, "Lorem ~4 amet"), [])
+        self.assertEqual(do_search(view.fragment_search, "Lorem ~4 adipiscing"), [])
+
+        # Test at least N words
+        self.assertEqual(do_search(view.fragment_search, "Lorem ~:4 consectetur"), [f1])
+        self.assertEqual(do_search(view.fragment_search, "Lorem ~:4 amet"), [f1])
+        self.assertEqual(do_search(view.fragment_search, "Lorem ~:4 adipiscing"), [])
+
+        # Test N or more words
+        self.assertEqual(do_search(view.fragment_search, "Lorem ~4: consectetur"), [f1])
+        self.assertEqual(do_search(view.fragment_search, "Lorem ~4: amet"), [])
+        # self.assertEqual(do_search(view.fragment_search, "Lorem ~4: adipiscing"), [f1])
+
+        # Test upper and lower bounds together
+        self.assertEqual(
+            do_search(view.fragment_search, "Lorem ~3:5 consectetur"), [f1]
+        )
+        self.assertEqual(do_search(view.fragment_search, "Lorem ~3:5 amet"), [f1])
+        self.assertEqual(do_search(view.fragment_search, "Lorem ~3:5 adipiscing"), [f1])
+        self.assertEqual(do_search(view.fragment_search, "Lorem ~3:5 sit"), [])
+        self.assertEqual(do_search(view.fragment_search, "Lorem ~3:5 elit"), [])
+
     def test_search_snippets(self):
         raw_content = (
             "Lorem ipsum dolor sit amet, <span class='test consectatur'>"

--- a/src/rard/research/tests/views/test_search.py
+++ b/src/rard/research/tests/views/test_search.py
@@ -473,7 +473,7 @@ class TestSearchView(TestCase):
         # Test N or more words
         self.assertEqual(do_search(view.fragment_search, "Lorem ~4: consectetur"), [f1])
         self.assertEqual(do_search(view.fragment_search, "Lorem ~4: amet"), [])
-        # self.assertEqual(do_search(view.fragment_search, "Lorem ~4: adipiscing"), [f1])
+        self.assertEqual(do_search(view.fragment_search, "Lorem ~4: adipiscing"), [f1])
 
         # Test upper and lower bounds together
         self.assertEqual(

--- a/src/rard/research/tests/views/test_search.py
+++ b/src/rard/research/tests/views/test_search.py
@@ -484,6 +484,14 @@ class TestSearchView(TestCase):
         self.assertEqual(do_search(view.fragment_search, "Lorem ~3:5 sit"), [])
         self.assertEqual(do_search(view.fragment_search, "Lorem ~3:5 elit"), [])
 
+        # Test wildcards work in combination
+        self.assertEqual(do_search(view.fragment_search, "Lor*m ~3:5 consect*"), [f1])
+
+        # Test quotation works
+        self.assertEqual(
+            do_search(view.fragment_search, 'Lorem ~3:5 "consectetur adipiscing"'), [f1]
+        )
+
     def test_search_snippets(self):
         raw_content = (
             "Lorem ipsum dolor sit amet, <span class='test consectatur'>"

--- a/src/rard/research/tests/views/test_search.py
+++ b/src/rard/research/tests/views/test_search.py
@@ -318,7 +318,7 @@ class TestSearchView(TestCase):
         self.assertEqual(do_search(view.fragment_search, "*Me*"), [f1, f2])
         self.assertEqual(do_search(view.fragment_search, "may"), [f1, f2])
         self.assertEqual(
-            do_search(view.fragment_search, "m!£$%^&()_+-=|\\{[}]:;@'~#<,>./ay"),
+            do_search(view.fragment_search, "m!£$%^&()_+-=|\\{[}];@'#<,>./ay"),
             [f1, f2],
         )
         self.assertEqual(do_search(view.fragment_search, "mav"), [])

--- a/src/rard/research/views/search.py
+++ b/src/rard/research/views/search.py
@@ -69,18 +69,20 @@ WILDCARD_SINGLE_CHAR = settings.WILDCARD_SINGLE_CHAR
 WILDCARD_MANY_CHAR = settings.WILDCARD_MANY_CHAR
 WILDCARD_PROXIMITY_IND = "~"
 WILDCARD_PROXIMITY_SEP = ":"
-WILDCARD_CHARS = [
+QUOTE_CHAR = '"'
+CTRL_CHARS = [
     WILDCARD_SINGLE_CHAR,
     WILDCARD_MANY_CHAR,
     WILDCARD_PROXIMITY_IND,
     WILDCARD_PROXIMITY_SEP,
+    QUOTE_CHAR,
 ]
 PUNCTUATION = punctuation + "£¬"
 # PUNCTUATION should include wildcard chars as it is used with content rather than
 # search terms
 # Remove wildcard characters for PUNCTUATION_BASE which is used to screen
 # out punctuation from search terms
-PUNCTUATION_BASE = PUNCTUATION.translate({ord(c): None for c in WILDCARD_CHARS})
+PUNCTUATION_BASE = PUNCTUATION.translate({ord(c): None for c in CTRL_CHARS})
 PUNCTUATION_RE = re.compile("[" + re.escape(PUNCTUATION_BASE) + "]")
 
 
@@ -107,7 +109,7 @@ class SearchView(LoginRequiredMixin, TemplateView, ListView):
             # only use regex for search terms containing wildcards
             self.lookup = "regex"
             # # If wildcard characters appear in keywords, use regex lookup
-            # if any([char in self.keywords for char in WILDCARD_CHARS]):
+            # if any([char in self.keywords for char in CTRL_CHARS]):
             #     self.lookup = "regex"
             # else:
             #     self.lookup = "contains"
@@ -183,11 +185,14 @@ class SearchView(LoginRequiredMixin, TemplateView, ListView):
             3. Captures individual words
             """
             # regex 1st alternative matches proximity wil
+            print(f"search string: {search_string}")
             keywords = re.findall(
                 r"(.+\s~\d?:?\d?\s.+|(?<=\")[^\"]*(?=\")|[^\s\"]+)", search_string
             )
             if self.lookup == "regex":
+                print(f"keywords before transform: {keywords}")
                 keywords = self.transform_keywords_to_regex(keywords)
+                print(f"keywords after transform: {keywords}")
             return keywords
 
         def transform_keywords_to_regex(self, keywords):

--- a/src/rard/research/views/search.py
+++ b/src/rard/research/views/search.py
@@ -217,10 +217,10 @@ class SearchView(LoginRequiredMixin, TemplateView, ListView):
             """
             # Proximity searches have one keyword and contain tilde character
             if len(keywords) == 1 and "~" in keywords[0]:
+                # Remove any '"' characters
+                kw = keywords[0].replace('"', "")
                 # Split keyword around proximity search
-                [(fore, prox_op, aft)] = re.findall(
-                    r"(.*)\s(~\d?:?\d?)\s(.*)", keywords[0]
-                )
+                [(fore, prox_op, aft)] = re.findall(r"(.*)\s(~\d?:?\d?)\s(.*)", kw)
                 # Fore and aft can be multi-word strings containing wildcards so loop back
                 fore = self.transform_keywords_to_regex([fore])
                 aft = self.transform_keywords_to_regex([aft])

--- a/src/rard/research/views/search.py
+++ b/src/rard/research/views/search.py
@@ -236,7 +236,7 @@ class SearchView(LoginRequiredMixin, TemplateView, ListView):
                 keywords = ["".join(fore) + prox_reg + "".join(aft)]
             else:
                 for i, kw in enumerate(keywords):
-                    reg_kw = r""  # \m matches start of word
+                    reg_kw = r"\y"  # \y matches start or end of word
                     for char in kw:
                         if char == WILDCARD_SINGLE_CHAR:
                             reg_kw += (
@@ -246,6 +246,7 @@ class SearchView(LoginRequiredMixin, TemplateView, ListView):
                             reg_kw += r"\w*"  # zero or more word characters
                         else:
                             reg_kw += char
+                    reg_kw += r"\y"
                     keywords[i] = reg_kw
             return keywords
 
@@ -317,7 +318,8 @@ class SearchView(LoginRequiredMixin, TemplateView, ListView):
             keywords_group = "|".join(keywords)
             keywords_group = r"(" + keywords_group + r")"
             words_after_group = rf"(.?\s(?:\S+\s){{0,{after}}})"
-            return words_before_group + keywords_group + words_after_group
+            snippet_regex = words_before_group + keywords_group + words_after_group
+            return snippet_regex
 
         def match(self, query_set, query_string, add_snippet=False):
             annotation_name = "cleaned{0}".format(self.cleaned_number)

--- a/src/rard/research/views/search.py
+++ b/src/rard/research/views/search.py
@@ -185,14 +185,11 @@ class SearchView(LoginRequiredMixin, TemplateView, ListView):
             3. Captures individual words
             """
             # regex 1st alternative matches proximity wil
-            print(f"search string: {search_string}")
             keywords = re.findall(
                 r"(.+\s~\d?:?\d?\s.+|(?<=\")[^\"]*(?=\")|[^\s\"]+)", search_string
             )
             if self.lookup == "regex":
-                print(f"keywords before transform: {keywords}")
                 keywords = self.transform_keywords_to_regex(keywords)
-                print(f"keywords after transform: {keywords}")
             return keywords
 
         def transform_keywords_to_regex(self, keywords):
@@ -239,7 +236,7 @@ class SearchView(LoginRequiredMixin, TemplateView, ListView):
                 keywords = ["".join(fore) + prox_reg + "".join(aft)]
             else:
                 for i, kw in enumerate(keywords):
-                    reg_kw = r"\m"  # \m matches start of word
+                    reg_kw = r""  # \m matches start of word
                     for char in kw:
                         if char == WILDCARD_SINGLE_CHAR:
                             reg_kw += (
@@ -249,9 +246,7 @@ class SearchView(LoginRequiredMixin, TemplateView, ListView):
                             reg_kw += r"\w*"  # zero or more word characters
                         else:
                             reg_kw += char
-                    reg_kw += r"\M"  # \M matches end of word
                     keywords[i] = reg_kw
-            print(keywords)
             return keywords
 
         def do_match(

--- a/src/rard/research/views/search.py
+++ b/src/rard/research/views/search.py
@@ -224,11 +224,14 @@ class SearchView(LoginRequiredMixin, TemplateView, ListView):
                 # Fore and aft can be multi-word strings containing wildcards so loop back
                 fore = self.transform_keywords_to_regex([fore])
                 aft = self.transform_keywords_to_regex([aft])
-                [(min_words, max_words)] = re.findall(r"~(\d)?:?(\d)?", prox_op)
+                [(min_words, isRange, max_words)] = re.findall(
+                    r"~(\d)?(:)?(\d)?", prox_op
+                )
                 min_words = "0" if not min_words else min_words
                 if max_words:
                     prox_reg = rf"\s(?:\w+\s){{{min_words},{max_words}}}"
                 elif min_words:
+                    min_words = min_words + "," if isRange else min_words
                     prox_reg = rf"\s(?:\w+\s){{{min_words}}}"
                 else:
                     # Shouldn't happen, just ignore

--- a/src/rard/templates/research/search_results.html
+++ b/src/rard/templates/research/search_results.html
@@ -69,6 +69,8 @@
                   match zero or more characters with {{WILDCARD_MANY_CHAR}},
                   or match proximity with "word1 ~n:m word2" where n and m indicate
                   the upper and lower bounds for the number of intervening words.
+                  Wilcards <strong>can</strong> be used with proximity searches; e.g.
+                  'hort?m ~1 biblio*'.
                 </small>
             </div>
             <div class='col-auto'>

--- a/src/rard/templates/research/search_results.html
+++ b/src/rard/templates/research/search_results.html
@@ -66,7 +66,9 @@
                 <input type="text" class="form-control alphabetum" name='q' {% if search_term %}value="{{ search_term }}"{% endif %} placeholder="Enter search terms">
                 <small id="searchHelpBlock" class="form-text text-muted">
                   Match a single character with {{WILDCARD_SINGLE_CHAR}},
-                  or match zero or more characters with {{WILDCARD_MANY_CHAR}}
+                  match zero or more characters with {{WILDCARD_MANY_CHAR}},
+                  or match proximity with "word1 ~n:m word2" where n and m indicate
+                  the upper and lower bounds for the number of intervening words.
                 </small>
             </div>
             <div class='col-auto'>


### PR DESCRIPTION
closes #299 

As described in the issue, this introduces the ability to carry out a proximity search where a search string like:

`Tarquinium ~5 ferens`

Would match: 

`Tarquinium Superbum regem adiit nouem libros ferens`

In the example above `~5` represents exactly five intervening words. You can also specify upper and lower bounds for the number of intervening words:

* `Tarquinium ~:5 libros` matches because `:5` means up to five words
* `Tarquinium ~3:5 libros` matches because `3:5` means between three and five words, but `Tarquinium ~3:5 adiit` would not match because there are only 2 intervening words

