### PR TITLE
Using htmx indicator to control loader display

### DIFF
--- a/src/rard/static/css/project.css
+++ b/src/rard/static/css/project.css
@@ -538,54 +538,39 @@ section.footnotes {
     max-width: 50%;
   }
 }
-.loader-wrapper {
-  display: flex;
-  justify-content: center;
-}
-#loader {
-  position: absolute;
-  min-height: fit-content;
-}
+
+/* HTML: <div class="loader"></div> */
 .loader {
-  visibility: hidden;
-  width: 50px;
-  aspect-ratio: 1;
-  display: grid;
+  opacity: 0;
+  display: inline-flex;
+  gap: 5px;
+  position: relative;
+  left:-30px;
+  height: 2rem;
 }
 .loader:before,
 .loader:after {
   content: "";
-  grid-area: 1/1;
-  --c: #0000 calc(100% / 3), #66929f 0 calc(2 * 100% / 3), #0000 0;
-  --c1: linear-gradient(90deg, var(--c));
-  --c2: linear-gradient(0deg, var(--c));
-  background: var(--c1), var(--c2), var(--c1), var(--c2);
-  background-size: 300% 4px, 4px 300%;
-  background-repeat: no-repeat;
-  animation: l11 1s infinite linear;
+  aspect-ratio: 1;
+  box-shadow: 0 0 0 3px inset #000;
+  animation: l4 1.5s infinite;
 }
 .loader:after {
-  margin: 10px;
-  transform: scaleX(-1);
-  animation-delay: -0.25s;
+  --s: -1;
+  animation-delay: 0.75s
 }
-@keyframes l11 {
-  0% {
-    background-position: 50% 0, 100% 100%, 0 100%, 0 0;
-  }
-  25% {
-    background-position: 0 0, 100% 50%, 0 100%, 0 0;
-  }
-  50% {
-    background-position: 0 0, 100% 0, 50% 100%, 0 0;
-  }
-  75% {
-    background-position: 0 0, 100% 0, 100% 100%, 0 50%;
-  }
-  75.01% {
-    background-position: 100% 0, 100% 0, 100% 100%, 0 50%;
-  }
-  100% {
-    background-position: 50% 0, 100% 0, 100% 100%, 0 100%;
-  }
+@keyframes l4 {
+  0%     {transform:scaleX(var(--s,1)) translate(0) rotate(0)}
+  16.67% {transform:scaleX(var(--s,1)) translate(-50%) rotate(0)}
+  33.33% {transform:scaleX(var(--s,1)) translate(-50%) rotate(90deg)}
+  50%,
+  100%   {transform:scaleX(var(--s,1)) translate(0) rotate(90deg)}
 }
+
+.htmx-request .loader{
+  opacity:1;
+}
+.htmx-request.loader{
+  opacity:1;
+}
+/* end loader */

--- a/src/rard/templates/research/antiquarian_detail.html
+++ b/src/rard/templates/research/antiquarian_detail.html
@@ -138,9 +138,19 @@
             <div>
               <h5>{% trans 'Bibliography' %}</h5>
             </div>
-            <div id="bib-buttons-area">
+            <div id="bib-buttons-area" class="d-flex justify-content-end">
               {% if has_object_lock and perms.research.change_bibliographyitem %}
-                <button type="button" class='btn text-primary p-0 ml-2' hx-get="{% url "antiquarian:refresh_bibliography" pk=antiquarian.pk %}" hx-trigger="click">{% trans 'Refresh bibliography from mentions' %}</button>
+                <div id="spinner" class="loader htmx-indicator"></div>
+                <button
+                    type="button"
+                    id="bib-refresh"
+                    class='btn text-primary p-0 ml-2'
+                    hx-get="{% url "antiquarian:refresh_bibliography" pk=antiquarian.pk %}"
+                    hx-trigger="click"
+                    hx-indicator="#spinner"
+                >
+                    {% trans 'Refresh bibliography from mentions' %}
+                </button>
               {% endif %}
             </div>
           </div>

--- a/src/rard/templates/research/citingauthor_detail.html
+++ b/src/rard/templates/research/citingauthor_detail.html
@@ -138,33 +138,24 @@
             <div>
                 <h5>{% trans 'Bibliography' %}</h5>
             </div>
-            <div class="loader-wrapper">
-            <div class="loader" id="loader"></div>
-        </div>
-            <div class="d-flex flex-column">
+            <div id="bib-buttons-area" class="d-flex justify-content-end">
                 {% if perms.research.change_citingauthor and has_object_lock %}
-                 <button type="button" id="bib-refresh" class='btn text-primary text-right d-block' hx-get="{% url "citingauthor:refresh_bibliography" pk=citingauthor.pk %}" hx-trigger="click">{% trans 'Refresh bibliography from mentions' %}</button>
-
+                <div id="spinner" class="loader htmx-indicator"></div>
+                <button
+                    type="button"
+                    id="bib-refresh"
+                    class='btn text-primary text-right d-block'
+                    hx-get="{% url "citingauthor:refresh_bibliography" pk=citingauthor.pk %}"
+                    hx-trigger="click"
+                    hx-indicator="#spinner"
+                >
+                    {% trans 'Refresh bibliography from mentions' %}
+                </button>
                 {% endif %}
             </div>
         </div>
-
         {% include 'research/partials/citing_author_bibliography_list.html' with bibliography_items=object.bibliography_items %}
     </section>
 
     {% endwith %}
-<script>
-    document.addEventListener("DOMContentLoaded", function() {
-        const refreshBtn = document.getElementById("bib-refresh");
-        refreshBtn.addEventListener("click", function() {
-            const loader = document.querySelector('.loader-wrapper > .loader');
-            if (loader) {
-                loader.style.visibility = 'visible';
-                setTimeout(function() {
-                    loader.style.visibility = 'hidden';
-                }, 2000);
-            }
-        });
-    });
-</script>
 {% endblock %}


### PR DESCRIPTION
There's a htmx way to control the loader display which is probably better to use since it's tied to the request (see [hx-indicator](https://htmx.org/attributes/hx-indicator/)).

I couldn't find your loader so I used a new one, but feel free to replace with something you think looks better. htmx uses the id to control display so there's no reason to have it inline with the button if you think overlaying it looks better.