### PR TITLE
Feature/381-accordion-display

### DIFF
--- a/src/rard/static/css/project.css
+++ b/src/rard/static/css/project.css
@@ -291,6 +291,10 @@ table.books-widget .book-order {
   font-family: Alphabetum !important;
 }
 
+.sans-serif {
+  font-family: "Noto Sans", sans-serif;
+}
+
 body {
   font-family: Arial, Helvetica, sans-serif;
 }

--- a/src/rard/templates/research/partials/ordered_work_area.html
+++ b/src/rard/templates/research/partials/ordered_work_area.html
@@ -34,11 +34,11 @@
                         {% if work.unknown == True and not flinks and not tlinks and not alinks %}
                         {% elif work.unknown == True %}
                         <b class='my-3 mr-1'><a href='{% url "work:detail" work.pk %}' >{{ work.name }}</a></b>
-                        <button type='button' class="btn btn-text text-primary pl-2" data-toggle="collapse" data-target="#list_{{work.pk}}" role="button" aria-expanded="false" aria-controls="list_{{work.pk}}"><i class='fas fa-caret-down'></i></button>
+                        <button type='button' class="btn btn-text text-primary pl-2 collapse-button" data-toggle="collapse" data-target="#list_{{work.pk}}" role="button" aria-expanded="false" aria-controls="list_{{work.pk}}"><i class='fas fa-chevron-down'><small class='ml-1 text-muted'>{% trans "Expand" %}</small></i></button>
 
                         {% else %}
                         <b class='my-3 mr-1'><a href='{% url "work:detail" work.pk %}'>{{ work.name }}</a></b>
-                        <button type='button' class="btn btn-text text-primary" data-toggle="collapse" data-target="#list_{{work.pk}}" role="button" aria-expanded="false" aria-controls="list_{{work.pk}}"><i class='fas fa-caret-down'></i></button>
+                        <button type='button' class="btn btn-text text-primary collapse-button" data-toggle="collapse" data-target="#list_{{work.pk}}" role="button" aria-expanded="false" aria-controls="list_{{work.pk}}"><i class='fas fa-chevron-down'><small class='ml-1 text-muted'>{% trans "Expand" %}</small></i></button>
 
                         {% if can_edit and has_object_lock %}
                         <button type='button' class='drag-handle btn btn-light btn-sm' style='cursor: move;' data-pos='{{ forloop.counter0 }}'><i class='fas fa-bars'></i></button>
@@ -109,3 +109,43 @@
 </div>
 
 {% endwith %}
+
+<script>
+    document.addEventListener('DOMContentLoaded', (event) => {
+        var collapseElementList = [].slice.call(document.querySelectorAll('ul.collapse'));
+        var collapseButtonList = [].slice.call(document.querySelectorAll('.collapse-button'));
+
+        function onClassChange(mutationList, observer) {
+            mutationList.forEach((mutation) => {
+                if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
+                    let targetElement = mutation.target;
+                    if (targetElement.classList.contains('show')) {
+                        // Find the button that controls this collapsible element and update the content
+                        var btn = collapseButtonList.find(btn => btn.getAttribute('data-target') === '#' + targetElement.id);
+                        if (btn) {
+                            btn.innerHTML = "<i class='fas fa-chevron-up'><small class='ml-1 text-muted'>{% trans 'Collapse' %}</small></i>";
+                        }
+                    } else {
+                        var btn = collapseButtonList.find(btn => btn.getAttribute('data-target') === '#' + targetElement.id);
+                        if (btn) {
+                            btn.innerHTML = "<i class='fas fa-chevron-down'><small class='ml-1 text-muted'>{% trans 'Expand' %}</small></i>";
+                        }
+                    }
+                }
+            });
+        }
+
+        // for each collapse element, attach a mutation observer
+        collapseElementList.forEach( (collapseEl)=> {
+            const observer = new MutationObserver(onClassChange);
+
+            // Start observing for changes to class
+            observer.observe(collapseEl, {
+                attributes: true,
+                attributeFilter: ['class']
+            });
+
+            });
+
+    });
+</script>

--- a/src/rard/templates/research/partials/ordered_work_area.html
+++ b/src/rard/templates/research/partials/ordered_work_area.html
@@ -17,7 +17,7 @@
         </ul>
     </div>
 
-    <button type='button' class="btn btn-outline-secondary btn-sm mb-2" data-toggle="collapse" data-target=".multi-collapse" aria-expanded="false" aria-controls="{% for work in object.ordered_works.all %}list_{{ work.pk }} {% endfor %}">{% trans "Expand all" %}</button>
+    <button type='button' id="multi-collapse-control" class="btn btn-outline-secondary btn-sm mb-2" data-toggle="collapse" data-target=".multi-collapse" aria-expanded="false" aria-controls="{% for work in object.ordered_works.all %}list_{{ work.pk }} {% endfor %}">{% trans "Expand all" %}</button>
 
     {% for work in object.ordered_works.all %}
 
@@ -34,11 +34,15 @@
                         {% if work.unknown == True and not flinks and not tlinks and not alinks %}
                         {% elif work.unknown == True %}
                         <b class='my-3 mr-1'><a href='{% url "work:detail" work.pk %}' >{{ work.name }}</a></b>
-                        <button type='button' class="btn btn-text text-primary pl-2 collapse-button" data-toggle="collapse" data-target="#list_{{work.pk}}" role="button" aria-expanded="false" aria-controls="list_{{work.pk}}"><i class='fas fa-chevron-down'><small class='ml-1 text-muted'>{% trans "Expand" %}</small></i></button>
+                        <span class="badge badge-secondary">{{ tlinks.count|add:flinks.count|add:alinks.count }}
+                        </span>
+
+                        <button type='button' class="btn btn-link btn-sm pl-2 collapse-button" data-toggle="collapse" data-target="#list_{{work.pk}}" role="button" aria-expanded="false" aria-controls="list_{{work.pk}}"><i class='fas fa-chevron-down'><small class='ml-1 text-muted sans-serif'>{% trans "Expand" %}</small></i></button>
 
                         {% else %}
                         <b class='my-3 mr-1'><a href='{% url "work:detail" work.pk %}'>{{ work.name }}</a></b>
-                        <button type='button' class="btn btn-text text-primary collapse-button" data-toggle="collapse" data-target="#list_{{work.pk}}" role="button" aria-expanded="false" aria-controls="list_{{work.pk}}"><i class='fas fa-chevron-down'><small class='ml-1 text-muted'>{% trans "Expand" %}</small></i></button>
+                        <button type='button' class="btn btn-link btn-sm collapse-button" data-toggle="collapse" data-target="#list_{{work.pk}}" role="button" aria-expanded="false" aria-controls="list_{{work.pk}}"><i class='fas fa-chevron-down'><small class='ml-1 text-muted sans-serif '>{% trans "Expand" %}</small></i></button> <span class="badge badge-secondary">{{ tlinks.count|add:flinks.count|add:alinks.count }}
+                        </span>
 
                         {% if can_edit and has_object_lock %}
                         <button type='button' class='drag-handle btn btn-light btn-sm' style='cursor: move;' data-pos='{{ forloop.counter0 }}'><i class='fas fa-bars'></i></button>
@@ -114,6 +118,8 @@
     document.addEventListener('DOMContentLoaded', (event) => {
         var collapseElementList = [].slice.call(document.querySelectorAll('ul.collapse'));
         var collapseButtonList = [].slice.call(document.querySelectorAll('.collapse-button'));
+        var expandAllBtn = document.getElementById('multi-collapse-control');
+
 
         function onClassChange(mutationList, observer) {
             mutationList.forEach((mutation) => {
@@ -123,14 +129,21 @@
                         // Find the button that controls this collapsible element and update the content
                         var btn = collapseButtonList.find(btn => btn.getAttribute('data-target') === '#' + targetElement.id);
                         if (btn) {
-                            btn.innerHTML = "<i class='fas fa-chevron-up'><small class='ml-1 text-muted'>{% trans 'Collapse' %}</small></i>";
+                            btn.innerHTML = "<i class='fas fa-chevron-up'><small class='ml-1 text-muted sans-serif '>{% trans 'Collapse' %}</small></i>";
                         }
                     } else {
                         var btn = collapseButtonList.find(btn => btn.getAttribute('data-target') === '#' + targetElement.id);
                         if (btn) {
-                            btn.innerHTML = "<i class='fas fa-chevron-down'><small class='ml-1 text-muted'>{% trans 'Expand' %}</small></i>";
+                            btn.innerHTML = "<i class='fas fa-chevron-down'><small class='ml-1 text-muted sans-serif '>{% trans 'Expand' %}</small></i>";
                         }
                     }
+
+                    // Only change expand all to collapse all if all are open
+                    if (collapseElementList.length === collapseElementList.filter(el => el.classList.contains('show')).length) {
+                        console.log("changing expand all")
+                        expandAllBtn.innerText = "{% trans 'Collapse all' %}";
+                    }
+                    else {expandAllBtn.innerText = "{% trans 'Expand all' %}";}
                 }
             });
         }
@@ -145,7 +158,7 @@
                 attributeFilter: ['class']
             });
 
-            });
+        });
 
     });
 </script>

--- a/src/rard/templates/research/partials/ordered_work_area.html
+++ b/src/rard/templates/research/partials/ordered_work_area.html
@@ -17,7 +17,7 @@
         </ul>
     </div>
 
-
+    <button type='button' class="btn btn-outline-secondary btn-sm mb-2" data-toggle="collapse" data-target=".multi-collapse" aria-expanded="false" aria-controls="{% for work in object.ordered_works.all %}list_{{ work.pk }} {% endfor %}">{% trans "Expand all" %}</button>
 
     {% for work in object.ordered_works.all %}
 
@@ -63,8 +63,8 @@
         {% endif %}
 
 
-        <ul class="collapse" id="list_{{work.pk}}">
-            <div class='ordered-list' id='multi-collapse'>
+        <ul class="collapse multi-collapse" id="list_{{work.pk}}">
+            <div class='ordered-list'>
 
                 {% if tlinks %}
                 {% for link in tlinks %}

--- a/src/rard/templates/research/partials/ordered_work_area.html
+++ b/src/rard/templates/research/partials/ordered_work_area.html
@@ -17,7 +17,7 @@
         </ul>
     </div>
 
-    <button type='button' id="multi-collapse-control" class="btn btn-outline-secondary btn-sm mb-2" data-toggle="collapse" data-target=".multi-collapse" aria-expanded="false" aria-controls="{% for work in object.ordered_works.all %}list_{{ work.pk }} {% endfor %}">{% trans "Expand all" %}</button>
+    <button type='button' id="multi-collapse-control" class="btn btn-outline-secondary btn-sm mb-2 exp" data-toggle="collapse" data-target=".multi-collapse" aria-expanded="false" aria-controls="{% for work in object.ordered_works.all %}list_{{ work.pk }} {% endfor %}">{% trans "Expand all" %}</button>
 
     {% for work in object.ordered_works.all %}
 
@@ -120,6 +120,23 @@
         var collapseButtonList = [].slice.call(document.querySelectorAll('.collapse-button'));
         var expandAllBtn = document.getElementById('multi-collapse-control');
 
+        $('#multi-collapse-control').click(function(e) {
+            // when the expand all button is clicked handle collapse/show manually (jQuery)
+            e.preventDefault();
+
+           if ($(this).hasClass('exp')) {
+
+                $('ul.collapse').each(function() {
+                    $(this).collapse('show');
+                    e.stopPropagation();
+                });
+            } else {
+                $('ul.collapse').each(function() {
+                    $(this).collapse('hide');
+                    e.stopPropagation();
+                });
+            }
+        });
 
         function onClassChange(mutationList, observer) {
             mutationList.forEach((mutation) => {
@@ -140,10 +157,12 @@
 
                     // Only change expand all to collapse all if all are open
                     if (collapseElementList.length === collapseElementList.filter(el => el.classList.contains('show')).length) {
-                        console.log("changing expand all")
                         expandAllBtn.innerText = "{% trans 'Collapse all' %}";
+                        expandAllBtn.classList.remove('exp');
                     }
-                    else {expandAllBtn.innerText = "{% trans 'Expand all' %}";}
+                    else {expandAllBtn.innerText = "{% trans 'Expand all' %}";
+                        expandAllBtn.classList.add('exp');
+                    }
                 }
             });
         }

--- a/src/rard/templates/research/partials/ordered_work_area.html
+++ b/src/rard/templates/research/partials/ordered_work_area.html
@@ -34,15 +34,14 @@
                         {% if work.unknown == True and not flinks and not tlinks and not alinks %}
                         {% elif work.unknown == True %}
                         <b class='my-3 mr-1'><a href='{% url "work:detail" work.pk %}' >{{ work.name }}</a></b>
-                        <span class="badge badge-secondary">{{ tlinks.count|add:flinks.count|add:alinks.count }}
-                        </span>
 
-                        <button type='button' class="btn btn-link btn-sm pl-2 collapse-button" data-toggle="collapse" data-target="#list_{{work.pk}}" role="button" aria-expanded="false" aria-controls="list_{{work.pk}}"><i class='fas fa-chevron-down'><small class='ml-1 text-muted sans-serif'>{% trans "Expand" %}</small></i></button>
+                        <button type='button' class="btn btn-outline-primary btn-sm pl-2 badge badge-pill collapse-button sans-serif" data-toggle="collapse" data-target="#list_{{work.pk}}" role="button" aria-expanded="false" aria-controls="list_{{work.pk}}">{{ tlinks.count|add:flinks.count|add:alinks.count }}<i class='fas ml-2 fa-chevron-down'>
+                        </i></button>
 
                         {% else %}
                         <b class='my-3 mr-1'><a href='{% url "work:detail" work.pk %}'>{{ work.name }}</a></b>
-                        <button type='button' class="btn btn-link btn-sm collapse-button" data-toggle="collapse" data-target="#list_{{work.pk}}" role="button" aria-expanded="false" aria-controls="list_{{work.pk}}"><i class='fas fa-chevron-down'><small class='ml-1 text-muted sans-serif '>{% trans "Expand" %}</small></i></button> <span class="badge badge-secondary">{{ tlinks.count|add:flinks.count|add:alinks.count }}
-                        </span>
+                        <button type='button' class="btn btn-outline-primary collapse-button sans-serif badge badge-pill" data-toggle="collapse" data-target="#list_{{work.pk}}" role="button" aria-expanded="false" aria-controls="list_{{work.pk}}">{{ tlinks.count|add:flinks.count|add:alinks.count }}<i class='fas ml-2 fa-chevron-down'>
+                        </i></button>
 
                         {% if can_edit and has_object_lock %}
                         <button type='button' class='drag-handle btn btn-light btn-sm' style='cursor: move;' data-pos='{{ forloop.counter0 }}'><i class='fas fa-bars'></i></button>
@@ -146,12 +145,15 @@
                         // Find the button that controls this collapsible element and update the content
                         var btn = collapseButtonList.find(btn => btn.getAttribute('data-target') === '#' + targetElement.id);
                         if (btn) {
-                            btn.innerHTML = "<i class='fas fa-chevron-up'><small class='ml-1 text-muted sans-serif '>{% trans 'Collapse' %}</small></i>";
+                            btn.querySelector("i").classList.remove("fa-chevron-down");
+                            btn.querySelector("i").classList.add("fa-chevron-up");
+
                         }
                     } else {
                         var btn = collapseButtonList.find(btn => btn.getAttribute('data-target') === '#' + targetElement.id);
                         if (btn) {
-                            btn.innerHTML = "<i class='fas fa-chevron-down'><small class='ml-1 text-muted sans-serif '>{% trans 'Expand' %}</small></i>";
+                            btn.querySelector("i").classList.remove("fa-chevron-up");
+                            btn.querySelector("i").classList.add("fa-chevron-down");
                         }
                     }
 

--- a/src/rard/templates/research/partials/ordered_work_area.html
+++ b/src/rard/templates/research/partials/ordered_work_area.html
@@ -17,6 +17,8 @@
         </ul>
     </div>
 
+
+
     {% for work in object.ordered_works.all %}
 
     <div class='drop-target' data-pos='{{ forloop.counter0 }}' data-objecttype='work'>
@@ -31,10 +33,12 @@
                     <div>
                         {% if work.unknown == True and not flinks and not tlinks and not alinks %}
                         {% elif work.unknown == True %}
-                        <b class='my-3 mr-3'><a href='{% url "work:detail" work.pk %}'>{{ work.name }}</a></b>
+                        <b class='my-3 mr-1'><a href='{% url "work:detail" work.pk %}' >{{ work.name }}</a></b>
+                        <button type='button' class="btn btn-text text-primary pl-2" data-toggle="collapse" data-target="#list_{{work.pk}}" role="button" aria-expanded="false" aria-controls="list_{{work.pk}}"><i class='fas fa-caret-down'></i></button>
 
                         {% else %}
-                        <b class='my-3 mr-3'><a href='{% url "work:detail" work.pk %}'>{{ work.name }}</a></b>
+                        <b class='my-3 mr-1'><a href='{% url "work:detail" work.pk %}'>{{ work.name }}</a></b>
+                        <button type='button' class="btn btn-text text-primary" data-toggle="collapse" data-target="#list_{{work.pk}}" role="button" aria-expanded="false" aria-controls="list_{{work.pk}}"><i class='fas fa-caret-down'></i></button>
 
                         {% if can_edit and has_object_lock %}
                         <button type='button' class='drag-handle btn btn-light btn-sm' style='cursor: move;' data-pos='{{ forloop.counter0 }}'><i class='fas fa-bars'></i></button>
@@ -59,8 +63,8 @@
         {% endif %}
 
 
-        <ul>
-            <div class='ordered-list'>
+        <ul class="collapse" id="list_{{work.pk}}">
+            <div class='ordered-list' id='multi-collapse'>
 
                 {% if tlinks %}
                 {% for link in tlinks %}


### PR DESCRIPTION
On an Anqituarian's detail page, the works under `Ordered Material` should now have the work titles and a button with "expand" and a downward chevron. Clicking this button will expand the contents of the work.
There is also a button to expand/collapse all, which works by toggling. This is done with bootstrap.

<img width="237" alt="image" src="https://github.com/user-attachments/assets/697f1f9b-5882-414c-93cc-3696e72e6171" />

closes #381 