### PR TITLE
499/fragment name in context

### DIFF
--- a/src/rard/research/models/base.py
+++ b/src/rard/research/models/base.py
@@ -102,7 +102,7 @@ class WorkLinkBaseModel(LinkBaseModel):
 
     def get_work_display_name_full(self):
         # to also show the antiquarian link as well as the work link
-        return "%s [= %s]" % (self.get_work_display_name(), self.get_display_name())
+        return f"{self.get_work_display_name()} [= {self.get_display_name()}]"
 
     def display_work_order_one_indexed(self):
         try:
@@ -649,8 +649,12 @@ class HistoricalBaseModel(TextObjectFieldMixin, LockableModel, BaseModel):
         names = self.get_link_names(show_certainty=False)
         return self._render_display_name(names, add_also=False)
 
-    def get_link_names(self, show_certainty=True):
+    def get_link_names(self, show_certainty=True, first_work=None):
         links = self.get_all_links().order_by("work", "antiquarian", "order")
+        if first_work:
+            first_links = links.filter(work=first_work)
+            other_links = links.exclude(work=first_work)
+            links = list(first_links) + list(other_links)
         names = []
         for link in links:
             if link.work and not link.work.unknown:
@@ -669,4 +673,9 @@ class HistoricalBaseModel(TextObjectFieldMixin, LockableModel, BaseModel):
     def get_display_name_option_b(self):
         # option b currently default
         names = self.get_link_names(show_certainty=False)
+        return self._render_display_name(names)
+
+    def get_display_name_for_work(self, work):
+        # put the link to the antiquarian first if it exists and then the others
+        names = self.get_link_names(show_certainty=False, first_work=work)
         return self._render_display_name(names)

--- a/src/rard/research/models/testimonium.py
+++ b/src/rard/research/models/testimonium.py
@@ -93,10 +93,14 @@ class Testimonium(HistoryModelMixin, HistoricalBaseModel):
     def get_all_names(self):
         return [link.get_display_name() for link in self.get_all_links()]
 
-    def get_link_names(self, show_certainty=True):
+    def get_link_names(self, show_certainty=True, first_work=None):
         links = self.get_all_links().order_by(
             "-work__unknown", "work", "antiquarian", "order"
         )
+        if first_work:
+            first_links = links.filter(work=first_work)
+            other_links = links.exclude(work=first_work)
+            links = list(first_links) + list(other_links)
         names = []
         for link in links:
             if link.work and not link.work.unknown:

--- a/src/rard/research/templatetags/name_in_context.py
+++ b/src/rard/research/templatetags/name_in_context.py
@@ -1,0 +1,8 @@
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def name_in_context(obj, work):
+    return obj.get_display_name_for_work(work)

--- a/src/rard/templates/research/partials/appositum_fragment_link_list_item.html
+++ b/src/rard/templates/research/partials/appositum_fragment_link_list_item.html
@@ -1,6 +1,6 @@
 {# Assumes a context object named 'link' and 'link_text'. Optional disable_link_controls to display but disable the link controls #}
 
-{% load i18n %}
+{% load i18n name_in_context %}
 
 {% with fragment=link.linked %}
 <div class='drop-target' data-pos='{{ forloop.counter0 }}' data-objecttype='anonymous_fragment'>
@@ -8,7 +8,7 @@
 <div id='anonymous_fragmentlink_{{ link.pk }}' data-link='{{ link.pk }}' data-antiquarian='{{ link.antiquarian.pk }}' draggable='false' data-objecttype='anonymous_fragment' data-pos='{{ forloop.counter0 }}' class='drag-item ordered-list-item rard-list-item d-flex justify-content-between'>
     <div>
         <li class="unstyled">
-                {% with fragment.get_display_name as link_text %}
+                {% with link_text=fragment|name_in_context:work %}
                 {% if perms.research.view_fragment %}
 
                 {% include 'research/partials/render_definite_indicators.html' with link=link %}

--- a/src/rard/templates/research/partials/fragment_link_list_item.html
+++ b/src/rard/templates/research/partials/fragment_link_list_item.html
@@ -1,6 +1,6 @@
 {# Assumes a context object named 'link' and 'link_text'. Optional disable_link_controls to display but disable the link controls #}
 
-{% load i18n %}
+{% load i18n name_in_context %}
 
 {% with fragment=link.linked %}
 <div class='drop-target' data-pos='{{ forloop.counter0 }}' data-objecttype='fragment'>
@@ -8,7 +8,7 @@
 <div id='fragmentlink_{{ link.pk }}' data-link='{{ link.pk }}' data-antiquarian='{{ link.antiquarian.pk }}' draggable='false' data-objecttype='fragment' data-pos='{{ forloop.counter0 }}' class='drag-item ordered-list-item rard-list-item d-flex justify-content-between'>
     <div>
         <li class="unstyled">
-                {% with fragment.get_display_name as link_text %}
+                {% with link_text=fragment|name_in_context:work %}
                 {% if perms.research.view_fragment %}
 
                 {% include 'research/partials/render_definite_indicators.html' with link=link %}

--- a/src/rard/templates/research/partials/testimonium_link_list_item.html
+++ b/src/rard/templates/research/partials/testimonium_link_list_item.html
@@ -1,6 +1,6 @@
 {# Assumes context objects named 'link' and 'link_text'. Optional disable_link_controls to display but disable the link controls #}
 
-{% load i18n %}
+{% load i18n name_in_context %}
 
 {% with testimonium=link.linked %}
 
@@ -10,7 +10,7 @@
 <div id='testimoniumlink_{{ link.pk }}' data-link='{{ link.pk }}' data-antiquarian='{{ link.antiquarian.pk }}' draggable='false' data-objecttype='testimonium' data-pos='{{ forloop.counter0 }}'  class='drag-item ordered-list-item rard-list-item d-flex justify-content-between'>
     <div>
         <li class="unstyled">
-                {% with testimonium.get_display_name as link_text %}
+                {% with link_text=testimonium|name_in_context:work %}
                 {% if perms.research.view_testimonium %}
 
                 {% include 'research/partials/render_definite_indicators.html' with link=link %}


### PR DESCRIPTION
closes #499 which asks for the fragment and testimonium display names on antiquarian's pages to put the most relevant name first. This solution uses a template tag, which uses the current work as an argument. When rendering the name, the link matching that work is put at the front and all other links follow.